### PR TITLE
메인 탭바 구현

### DIFF
--- a/Projects/Sseudam/Project.swift
+++ b/Projects/Sseudam/Project.swift
@@ -24,6 +24,6 @@ let project = Project.makeApp(
     ],
   ],
   dependencies: [
-    
+    .SPM.TCA
   ]
 )

--- a/Projects/Sseudam/Sources/CustomTabBar.swift
+++ b/Projects/Sseudam/Sources/CustomTabBar.swift
@@ -1,0 +1,84 @@
+//
+//  CustomTabBar.swift
+//  Sseudam
+//
+//  Created by Jiyeon on 6/6/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+
+// TODO: - DesignSystem에 추가하기
+/// 임시 탭바
+struct CustomTabBar: View {
+  let selectedTab: TabItem
+  var onTabSelected: ((TabItem) -> Void)? = nil
+  
+  var body: some View {
+    HStack(spacing: 12) {
+      ForEach(TabItem.allCases, id: \.self) { tab in
+        TabButton(tab)
+      }
+    }
+    .frame(height: 62)
+    .padding(.horizontal, 8)
+    
+  }
+  
+  
+  @ViewBuilder
+  private func TabButton(_ tab: TabItem) -> some View {
+    let isActive: Bool = selectedTab == tab
+    VStack(spacing: 0) {
+      Image(systemName: tab.iconName)
+      Text(tab.title)
+        .font(.callout)
+        .fontWeight(.medium)
+    }
+    .foregroundStyle(isActive ? .blue : .gray)
+    .frame(maxWidth: .infinity)
+    .onTapGesture {
+      onTabSelected?(tab)
+      
+    }
+  }
+  
+  func tabSelected(_ action: @escaping (TabItem) -> Void) -> Self {
+    var item = self
+    item.onTabSelected = action
+    return item
+  }
+}
+
+
+enum TabItem: String, CaseIterable, Identifiable {
+  case home
+  case search
+  case profile
+  
+  var id: String { rawValue }
+  
+  /// 이미지
+  var iconName: String {
+    switch self {
+    case .home:
+      return "house.fill"
+    case .search:
+      return "magnifyingglass"
+    case .profile:
+      return "person.fill"
+    }
+  }
+  
+  /// 탭바 아래에 표시할 텍스트
+  var title: String {
+    switch self {
+    case .home:
+      return "홈"
+    case .search:
+      return "마이펫"
+    case .profile:
+      return "마이"
+    }
+  }
+}

--- a/Projects/Sseudam/Sources/SseudamApp.swift
+++ b/Projects/Sseudam/Sources/SseudamApp.swift
@@ -12,7 +12,7 @@ import SwiftUI
 struct SseudamApp: App {
   var body: some Scene {
     WindowGroup {
-      EmptyView()
+      SseudamView()
     }
   }
 }

--- a/Projects/Sseudam/Sources/SseudamFeature.swift
+++ b/Projects/Sseudam/Sources/SseudamFeature.swift
@@ -1,5 +1,5 @@
 //
-//  SseudamReducer.swift
+//  SseudamFeature.swift
 //  Sseudam
 //
 //  Created by Jiyeon on 6/6/25.
@@ -10,7 +10,7 @@ import Foundation
 import ComposableArchitecture
 
 @Reducer
-struct SseudamReducer {
+struct SseudamFeature {
   
   @ObservableState
   struct State {

--- a/Projects/Sseudam/Sources/SseudamReducer.swift
+++ b/Projects/Sseudam/Sources/SseudamReducer.swift
@@ -1,0 +1,39 @@
+//
+//  SseudamReducer.swift
+//  Sseudam
+//
+//  Created by Jiyeon on 6/6/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import ComposableArchitecture
+
+@Reducer
+struct SseudamReducer {
+  
+  @ObservableState
+  struct State {
+    var selectedTab: TabItem = .home
+  }
+  
+  enum Action: BindableAction {
+    case binding(BindingAction<State>)
+    case selectTab(TabItem)
+  }
+  
+  var body: some ReducerOf<Self> {
+    BindingReducer()
+    
+    Reduce { state, action in
+      switch action {
+      case let .selectTab(tab):
+        state.selectedTab = tab
+        return .none
+        
+      default: return .none
+      }
+    }
+  }
+  
+}

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -21,11 +21,11 @@ struct SseudamView: View {
       Group {
         switch store.selectedTab {
         case .home:
-          SampleView(color: .blue)
+          EmptyView()
         case .search:
-          SampleView(color: .brown)
+          EmptyView()
         case .profile:
-          SampleView(color: .pink)
+          EmptyView()
         }
       }
       Spacer()
@@ -37,13 +37,6 @@ struct SseudamView: View {
   }
 }
 
-struct SampleView: View {
-  let color: Color
-  var body: some View {
-    color
-      .ignoresSafeArea()
-  }
-}
 #Preview {
   SseudamView()
 }

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -18,15 +18,13 @@ struct SseudamView: View {
   
   var body: some View {
     VStack {
-      Group {
-        switch store.selectedTab {
-        case .home:
-          EmptyView()
-        case .search:
-          EmptyView()
-        case .profile:
-          EmptyView()
-        }
+      switch store.selectedTab {
+      case .home:
+        EmptyView()
+      case .search:
+        EmptyView()
+      case .profile:
+        EmptyView()
       }
       Spacer()
       CustomTabBar(selectedTab: store.selectedTab)

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -7,13 +7,44 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 
 struct SseudamView: View {
+  @Bindable var store: StoreOf<SseudamReducer> = Store(
+    initialState: SseudamReducer.State()
+  ) {
+    SseudamReducer()
+  }
+  
   var body: some View {
-    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    VStack {
+      Group {
+        switch store.selectedTab {
+        case .home:
+          SampleView(color: .blue)
+        case .search:
+          SampleView(color: .brown)
+        case .profile:
+          SampleView(color: .pink)
+        }
+      }
+      Spacer()
+      CustomTabBar(selectedTab: store.selectedTab)
+        .tabSelected { tab in
+          store.send(.selectTab(tab))
+        }
+    }
   }
 }
 
+struct SampleView: View {
+  let color: Color
+  var body: some View {
+    color
+      .ignoresSafeArea()
+  }
+}
 #Preview {
   SseudamView()
 }
+

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -10,10 +10,10 @@ import SwiftUI
 import ComposableArchitecture
 
 struct SseudamView: View {
-  @Bindable var store: StoreOf<SseudamReducer> = Store(
-    initialState: SseudamReducer.State()
+  @Bindable var store: StoreOf<SseudamFeature> = Store(
+    initialState: SseudamFeature.State()
   ) {
-    SseudamReducer()
+    SseudamFeature()
   }
   
   var body: some View {


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #3 

## 🔎 작업 내용
1. 임시 탭바 구현
  - 디자인시스템과 리소스가 아직 없어서 임시로 커스텀 탭바 구현
  - 추후 새로 구현 필요
 2. 메인 화면 구현
  - 추후 각 탭에 맞는 화면 연결 필요

## 📷 스크린샷
<img src = "https://github.com/user-attachments/assets/9a0ba04e-a19a-4ea7-b6a5-d959006ef72b" width = "40%">


## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a custom tab bar with Home, Search, and Profile sections, featuring icons and localized Korean titles.
  - Added a tab-driven main view, allowing users to switch between sections using the new tab bar.
- **Improvements**
  - Updated the app’s initial screen to display the main view instead of a placeholder.
- **Architecture**
  - Integrated state management for tab selection, ensuring smooth tab switching and future extensibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->