### PR TITLE
KeyChain, UserDefaults 추가

### DIFF
--- a/Projects/Domain/Home/HomeDomainInterface/Project.swift
+++ b/Projects/Domain/Home/HomeDomainInterface/Project.swift
@@ -15,7 +15,8 @@ let project = Project.makeStaticLibraryProject(
     .Core.DesignKit,
     .Shared.ThirdParty,
     .Shared.Utility,
-    .Shared.KeyChain
+    .Shared.KeyChain,
+    .Shared.UserDefaults
   ],
   nameSuffix: "Interface"
 )

--- a/Projects/Domain/Home/HomeDomainInterface/Project.swift
+++ b/Projects/Domain/Home/HomeDomainInterface/Project.swift
@@ -15,6 +15,7 @@ let project = Project.makeStaticLibraryProject(
     .Core.DesignKit,
     .Shared.ThirdParty,
     .Shared.Utility,
+    .Shared.KeyChain
   ],
   nameSuffix: "Interface"
 )

--- a/Projects/Shared/KeyChain/Project.swift
+++ b/Projects/Shared/KeyChain/Project.swift
@@ -1,0 +1,29 @@
+//
+//  Project.swift
+//  CoreManifests
+//
+//  Created by Jiyeon on 6/16/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+  name: "KeyChain",
+  organizationName: "Sseudam.a2bo.ios",
+  options: .default,
+  settings: .default,
+  targets: [
+    .target(
+      name: "KeyChain",
+      destinations: .iOS,
+      product: .staticLibrary,
+      bundleId: "Sseudam.a2bo.ios.KeyChain",
+      deploymentTargets: .iOS("17.0"),
+      infoPlist: .extendingDefault(with: [:]),
+      sources: ["Sources/**"],
+      dependencies: [
+      ]
+    )
+  ]
+)

--- a/Projects/Shared/KeyChain/Sources/KeyChainKey.swift
+++ b/Projects/Shared/KeyChain/Sources/KeyChainKey.swift
@@ -1,0 +1,13 @@
+//
+//  KeyChainKey.swift
+//  KeyChain
+//
+//  Created by Jiyeon on 6/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public enum KeychainKey: String {
+  case refreshToken
+}

--- a/Projects/Shared/KeyChain/Sources/KeyChainService.swift
+++ b/Projects/Shared/KeyChain/Sources/KeyChainService.swift
@@ -1,0 +1,116 @@
+//
+//  KeyChainService.swift
+//  KeyChain
+//
+//  Created by Jiyeon on 6/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct KeyChainService {
+  
+  private static let bundleId = Bundle.main.bundleIdentifier ?? ""
+  
+  /// 키체인 저장 메서드
+  ///
+  /// 사용 예시:
+  /// ```swift
+  /// KeychainWrapper.save("abcd1234", key: .accessToken)
+  /// ```
+  @discardableResult
+  public static func save<T: Codable>(_ value: T, forKey key: KeychainKey) -> Bool {
+    do {
+      let data = try JSONEncoder().encode(value)
+      let query: [CFString: Any] = [
+        kSecClass: kSecClassGenericPassword,
+        kSecAttrService: bundleId,
+        kSecAttrAccount: key.rawValue,
+        kSecValueData: data
+      ]
+      
+      SecItemDelete(query as CFDictionary)
+      
+      let status = SecItemAdd(query as CFDictionary, nil) == errSecSuccess
+      if !status {
+        print("""
+        [KeyChain Save Failed]
+          - Key: \(key.rawValue)
+          - Value: \(value)
+          - Error: \(status.description)
+        """)
+      }
+      return status
+    } catch {
+      print("""
+      [KeyChain Save Error]
+        - Key: \(key.rawValue)
+        - Value: \(value)
+        - Error: \(error.localizedDescription)
+      """)
+      return false
+    }
+  }
+  
+  /// 키체인 불러오기 메서드
+  ///
+  /// 사용 예시:
+  /// ```swift
+  /// var token: String? =
+  ///   KeychainWrapper.read(key: .accessToken)
+  /// ```
+  public static func read<T: Codable>(forKey key: KeychainKey) -> T? {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: bundleId,
+      kSecAttrAccount: key.rawValue,
+      kSecReturnData:  kCFBooleanTrue as Any,
+      kSecMatchLimit: kSecMatchLimitOne
+    ]
+    
+    var dataTypeRef: AnyObject?
+    let status = SecItemCopyMatching(query as CFDictionary, &dataTypeRef)
+    
+    guard status == errSecSuccess, let data = dataTypeRef as? Data else {
+      print("""
+      [KeyChain Read Failed]
+        - Key: \(key.rawValue)
+      """)
+      return nil
+    }
+    
+    do {
+      return try JSONDecoder().decode(T.self, from: data)
+    } catch {
+      print("""
+      [KeyChain Read Error]
+        - Key: \(key.rawValue)
+        - Error: \(error.localizedDescription)
+      """)
+      return nil
+    }
+  }
+  
+  /// 키체인 삭제 메서드
+  ///
+  /// 사용 예시:
+  /// ```swift
+  /// KeychainWrapper.delete(key: .accessToken)
+  /// ```
+  @discardableResult
+  public static func delete(forKey key: KeychainKey) -> Bool {
+    let query: [CFString: Any] = [
+      kSecClass: kSecClassGenericPassword,
+      kSecAttrService: bundleId,
+      kSecAttrAccount: key.rawValue
+    ]
+    let status = SecItemDelete(query as CFDictionary) == errSecSuccess
+    if !status {
+      print("""
+      [KeyChain Delete Failed]
+        - Key: \(key.rawValue)
+      """)
+    }
+    return status
+  }
+}

--- a/Projects/Shared/UserDefaults/Project.swift
+++ b/Projects/Shared/UserDefaults/Project.swift
@@ -1,0 +1,29 @@
+//
+//  Project.swift
+//  CoreManifests
+//
+//  Created by Jiyeon on 6/16/25.
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project(
+  name: "UserDefaults",
+  organizationName: "Sseudam.a2bo.ios",
+  options: .default,
+  settings: .default,
+  targets: [
+    .target(
+      name: "UserDefaults",
+      destinations: .iOS,
+      product: .staticLibrary,
+      bundleId: "Sseudam.a2bo.ios.UserDefaults",
+      deploymentTargets: .iOS("17.0"),
+      infoPlist: .extendingDefault(with: [:]),
+      sources: ["Sources/**"],
+      dependencies: [
+      ]
+    )
+  ]
+)

--- a/Projects/Shared/UserDefaults/Sources/UserDefaults.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaults.swift
@@ -1,0 +1,36 @@
+//
+//  UserDefaults.swift
+//  UserDefaults
+//
+//  Created by Jiyeon on 6/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+/// UserDefaults에 저장되는 키 값들을 정의한 열거형
+/// 모든 UserDefaults 키를 한 곳에서 관리하여 문자열 오타로 인한 오류를 방지.
+public enum UserDefault: UserDefaultProtocol {
+  
+  case _accessToken
+  
+  /// _accessToken 값을 쉽게 가져오고 저장할 수 있는 정적 프로퍼티.
+  ///
+  ///
+  /// 값을 저장할 때 -> `UserDefault.accessToken = "access_token"`
+  /// 값을 가져올 때 -> `let token = UserDefault.accessToken`
+  public static var accessToken: String? {
+    get { Self._accessToken.load() }
+    set {
+      if newValue == nil { Self._accessToken.delete() }
+      else { Self._accessToken.save(newValue) }
+    }
+  }
+  
+  /// 특정 키의 값을 UserDefaults에서 삭제하는 편의 메서드
+  /// 사용 예: UserDefault.delete(._accessToken)
+  public static func delete(_ key: Self) { key.delete() }
+  
+  
+  
+}

--- a/Projects/Shared/UserDefaults/Sources/UserDefaultsProtocol.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaultsProtocol.swift
@@ -1,0 +1,31 @@
+//
+//  UserDefaultsProtocol.swift
+//  UserDefaults
+//
+//  Created by Jiyeon on 6/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+protocol UserDefaultProtocol: RawRepresentable where RawValue == String { }
+
+extension UserDefaultProtocol {
+  public var rawValue: String { String(describing: self) }
+  
+  public init?(rawValue: String) {
+    self.init(rawValue: rawValue)
+  }
+  
+  public func save<T: Sendable & Decodable>(_ value: T?) {
+    UserDefaults.standard.set(value, forKey: self.rawValue)
+  }
+  
+  public func load<T: Sendable & Decodable>() -> T? {
+    return UserDefaults.standard.object(forKey: self.rawValue) as? T
+  }
+  
+  public func delete() {
+    UserDefaults.standard.removeObject(forKey: self.rawValue)
+  }
+}

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
@@ -45,6 +45,7 @@ public enum Shared: String, ModuleRepresentable {
   case ThirdParty
   case Utility
   case KeyChain
+  case UserDefaults
   public var typePath: String { "Shared" }
 }
 
@@ -127,6 +128,7 @@ extension TargetDependency {
     public static let ThirdParty = Self.project(.shared(.ThirdParty))
     public static let Utility = Self.project(.shared(.Utility))
     public static let KeyChain = Self.project(.shared(.KeyChain))
+    public static let UserDefaults = Self.project(.shared(.UserDefaults))
   }
   
   public struct SPM: TargetDependencyDelegate {

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
@@ -44,6 +44,7 @@ public enum Core: String, ModuleRepresentable {
 public enum Shared: String, ModuleRepresentable {
   case ThirdParty
   case Utility
+  case KeyChain
   public var typePath: String { "Shared" }
 }
 
@@ -125,6 +126,7 @@ extension TargetDependency {
   public struct Shared: TargetDependencyDelegate {
     public static let ThirdParty = Self.project(.shared(.ThirdParty))
     public static let Utility = Self.project(.shared(.Utility))
+    public static let KeyChain = Self.project(.shared(.KeyChain))
   }
   
   public struct SPM: TargetDependencyDelegate {


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #11

## 🔎 작업 내용
작업 속도를 빠르게 하기 위해 피다에 있던 코드 가져왔습니다.
키체인은 `save`에서 이미 키 존재 시 삭제하고 다시 저장하는 방식을 사용하기 때문에 `update`를 없애고 `save`로 통일해서 사용하도록 변경했습니다.

## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a KeyChain module for secure storage, including support for saving, retrieving, and deleting Codable data.
  - Added a UserDefaults module with type-safe access and management of stored values.
- **Improvements**
  - Enhanced dependency management to support the new KeyChain and UserDefaults modules.
  - Centralized and streamlined handling of secure and persistent data storage within the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->