### PR TITLE
Feature/#46 마이펫 페이지 바텀시트 디테일 UI 구현

### DIFF
--- a/Projects/Core/Cache/Sources/CacheActor.swift
+++ b/Projects/Core/Cache/Sources/CacheActor.swift
@@ -50,6 +50,16 @@ extension CacheActor {
       )
     }
   }
+  
+  public var MY_PET_INFO_CACHE: TwoTierCache<MyPetCacheKey, MyPetInfoCacheModel> {
+    get async throws {
+      return try await cache(
+        .myPetInfo,
+        ttl: .high,
+        eviction: .none
+      )
+    }
+  }
 }
 
 /*

--- a/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
+++ b/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
@@ -28,3 +28,16 @@ public enum SampleCacheKey: CacheKey {
     }
   }
 }
+
+public enum MyPetCacheKey: CacheKey {
+  case myPetInfo
+  
+  public var directory: String { "MyPet" }
+  public var fileName: String { "\(identifier).cache" }
+  
+  public var identifier: String {
+    switch self {
+    case .myPetInfo: "my_pet_info"
+    }
+  }
+}

--- a/Projects/Core/Cache/Sources/CacheModel/MyPetInfoCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/MyPetInfoCacheModel.swift
@@ -1,0 +1,28 @@
+//
+//  MyPetInfoCacheModel.swift
+//  Cache
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct MyPetInfoCacheModel: Sendable, Equatable, Codable {
+  public let nickname: String
+  public let currentPoint: Int
+  public let goalPoint: Int
+  public let levelType: String
+  
+  public init(
+    nickname: String,
+    point: Int,
+    levelType: String,
+    maxLevelStandard: Int
+  ) {
+    self.nickname = nickname
+    self.currentPoint = point
+    self.goalPoint = maxLevelStandard
+    self.levelType = levelType
+  }
+}

--- a/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
+++ b/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
@@ -80,6 +80,7 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
     .frame(maxWidth: .infinity)
     .background(ColorSet.Background.Primary)
     .clipCorners(.Number16, corners: [.topLeft, .topRight])
+    .elevation(level: .small, cornerRadius: .Number16)
     .highPriorityGesture(dragGesture())
   }
   

--- a/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
+++ b/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
@@ -23,6 +23,9 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
   @State private var isDragging: Bool = false
   @State private var initialHeight: CGFloat = 0
   
+  /// 외부에서 `Environment`로 드래그 가능 여부를 제어할 수 있도록 설정
+  @Binding private var isBottomSheetDragEnabled: Bool
+  
   // 중간 임계값 (콘텐츠 전환 기준)
   private let midHeight: CGFloat
 
@@ -30,6 +33,7 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
     minHeight: CGFloat,
     maxHeight: CGFloat? = nil,
     midHeight: CGFloat? = nil,
+    isBottomSheetDragEnabled: Binding<Bool>,
     @ViewBuilder smallContent: @escaping () -> SmallContent,
     @ViewBuilder largeContent: @escaping () -> LargeContent
   ) {
@@ -40,6 +44,8 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
     self.largeContent = largeContent
     // 시작 시에는 minHeight
     self._currentHeight = State(initialValue: minHeight)
+    // 외부에서 드래그 가능 여부를 제어할 수 있도록 설정
+    self._isBottomSheetDragEnabled = isBottomSheetDragEnabled
   }
   
   public var body: some View {
@@ -81,7 +87,7 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
     .background(ColorSet.Background.Primary)
     .clipCorners(.Number16, corners: [.topLeft, .topRight])
     .elevation(level: .small, cornerRadius: .Number16)
-    .highPriorityGesture(dragGesture())
+    .gesture( isBottomSheetDragEnabled ? dragGesture() : nil)
   }
   
   private func dragGesture() -> some Gesture {

--- a/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
+++ b/Projects/Core/DesignKit/Sources/Component/BottomSheet/CustomBottomSheet.swift
@@ -60,7 +60,7 @@ public struct CustomBottomSheet<SmallContent: View, LargeContent: View>: View {
   }
   
   private var sheetView: some View {
-    VStack(spacing: 0) {
+    VStack(spacing: .Number8) {
       VStack {
         RoundedRectangle(cornerRadius: 2)
           .fill(ColorSet.Gray._200)

--- a/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
+++ b/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
@@ -10,13 +10,31 @@ import Foundation
 import PetDomainInterface
 import PetDataInterface
 import NetworkKit
+import Cache
 
 public extension PetRepository {
   static func live(networker: NetworkKit) -> PetRepository {
     return .init(
       getPetInfo: {
+        let cacheKey = MyPetCacheKey.myPetInfo
+        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
+        if let hitData = await cache.value(forKey: cacheKey) {
+          let entity = PetInfoEntity(hitData)
+          return entity /// `cache-hit`인 경우, 캐시된 데이터를 반환
+        }
+        
         let endpoint = PetEndpoint.getPetInfo()
-        return try await networker.execute(with: endpoint).toEntity()
+        let entity = try await networker.execute(with: endpoint).toEntity()
+        
+        let cacheModel = MyPetInfoCacheModel(
+          nickname: entity.nickname,
+          point: entity.currentPoint,
+          levelType: entity.levelType.rawValue,
+          maxLevelStandard: entity.goalPoint
+        )
+        try await cache.insert(cacheModel, forKey: cacheKey)
+        /// `cache-miss`인 경우, 네트워크로부터 받은 데이터를 캐시에 저장하고 반환
+        return entity
       }
     )
   }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Cache
 
 public struct PetInfoEntity: Sendable, Equatable {
   public let nickname: String
@@ -24,6 +25,18 @@ public struct PetInfoEntity: Sendable, Equatable {
     self.currentPoint = point
     self.goalPoint = maxLevelStandard
     self.levelType = LevelType(rawValue: levelType) ?? .유년기
+  }
+  
+  /// Cache데이터를 PetInfoEntity로 변환하는 초기화 메서드
+  public init(
+    _ cacheModel: MyPetInfoCacheModel
+  ) {
+    self.init(
+      nickname: cacheModel.nickname,
+      point: cacheModel.currentPoint,
+      levelType: cacheModel.levelType,
+      maxLevelStandard: cacheModel.goalPoint
+    )
   }
 }
 

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
@@ -23,8 +23,10 @@ public struct PetInfoEntity: Sendable, Equatable {
   ) {
     self.nickname = nickname
     self.currentPoint = point
-    self.goalPoint = maxLevelStandard
     self.levelType = LevelType(rawValue: levelType) ?? .유년기
+    
+    if LevelType(rawValue: levelType) == .궁극체 { self.goalPoint = point }
+    else { self.goalPoint = maxLevelStandard }
   }
   
   /// Cache데이터를 PetInfoEntity로 변환하는 초기화 메서드
@@ -46,4 +48,14 @@ public enum LevelType: String, Sendable {
   case 성숙기 = "LEVEL_3" 
   case 완전체 = "LEVEL_4"
   case 궁극체 = "SPECIAL"
+  
+  public var transformed: Int {
+    switch self {
+    case .유년기: return 1
+    case .성장기: return 2
+    case .성숙기: return 3
+    case .완전체: return 4
+    case .궁극체: return 5
+    }
+  }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -10,7 +10,6 @@ import SwiftUI
 import ComposableArchitecture
 import UserDefaults
 import Utility
-import Cache
 
 import AuthFeature
 import PetDomainInterface
@@ -116,16 +115,6 @@ extension MyPetFeature {
   ) -> Effect<Action> {
     .run { send in
       do {
-        /// 캐시 키 생성
-        let cacheKey = MyPetCacheKey.myPetInfo
-        
-        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
-        if let hitData = await cache.value(forKey: cacheKey) {
-          /// 캐시 hit되면 그대로 사용
-          let entity = PetInfoEntity(hitData)
-          await send(.fetchMyPetInfoResult(.success(entity)))
-        }
-        /// 캐시 miss되면 API 호출
         let entity = try await useCase.execute()
         await send(.fetchMyPetInfoResult(.success(entity)))
       } catch is CancellationError {

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -26,6 +26,24 @@ public struct MyPetFeature {
     public var myPetInfo: PetInfoEntity?
     public var isLoggedIn: Bool = false
 
+    public var catCards = [
+      CatCard(image: "cat1", isLocked: false),
+      CatCard(image: "cat2", isLocked: false),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true)
+    ]
+    
+    public var growthRecords = [
+      GrowthRecord(level: "Lv.1", title: "작고 소중한 {{고양이 이름}}", description: "", date: "YY.MM.DD.", stampCount: "0쓰담", isLocked: false),
+      GrowthRecord(level: "Lv.2", title: "호기심 가득한 {{고양이 이...", description: "", date: "YY.MM.DD.", stampCount: "20쓰담", isLocked: false),
+      GrowthRecord(level: "Lv.3", title: "쑥쑥 자라나는 {{고양이...", description: "", date: nil, stampCount: "110쓰담", isLocked: true),
+      GrowthRecord(level: "Lv.4", title: "왕 커서 귀여운{{고양이 이...", description: "", date: nil, stampCount: "N쓰담", isLocked: true),
+      GrowthRecord(level: "Special", title: "{{스페셜 문구}} {{고양이...", description: "", date: nil, stampCount: "N쓰담", isLocked: true)
+    ]
+    
+    
     public init() {}
   }
   
@@ -77,6 +95,7 @@ public struct MyPetFeature {
           return .none
         case let .failure(error):
           state.myPetInfo = nil
+          print("Error fetching pet info: \(error)")
           return .none
         }
         

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -9,7 +9,12 @@
 import SwiftUI
 import ComposableArchitecture
 import UserDefaults
+import Utility
+import Cache
+
 import AuthFeature
+import PetDomainInterface
+
 
 @Reducer
 public struct MyPetFeature {
@@ -19,7 +24,7 @@ public struct MyPetFeature {
   @ObservableState
   public struct State {
     public var path = StackState<Path.State>()
-    
+    public var myPetInfo: PetInfoEntity?
     public var isLoggedIn: Bool = false
 
     public init() {}
@@ -30,6 +35,9 @@ public struct MyPetFeature {
     case path(StackActionOf<Path>)
     case onAppear
     case checkLoggedIn
+    case fetchMyPetInfo
+    
+    case fetchMyPetInfoResult(Result<PetInfoEntity, NetworkError>)
     
     case petNicknameButtonTapped
     case petDetailButtonTapped
@@ -45,6 +53,8 @@ public struct MyPetFeature {
     case requestLogin(Bool)
   }
   
+  @Dependency(\.CheckPetInfoUseCase) var checkPetInfoUseCase
+  
   public var body: some ReducerOf<Self> {
     BindingReducer()
     Reduce { state, action in
@@ -55,7 +65,21 @@ public struct MyPetFeature {
         
       case .checkLoggedIn:
         state.isLoggedIn = UserDefaultsKeys.isLoggedIn ?? false
+        if state.isLoggedIn { return .send(.fetchMyPetInfo) }
         return .none
+        
+      case .fetchMyPetInfo:
+        return fetchMyPetInfoEffect(checkPetInfoUseCase)
+        
+      case let .fetchMyPetInfoResult(result):
+        switch result {
+        case let .success(entity):
+          state.myPetInfo = entity
+          return .none
+        case let .failure(error):
+          state.myPetInfo = nil
+          return .none
+        }
         
       case .petDetailButtonTapped:
         state.path.append(.petDetail(MyPetDetailFeature.State()))
@@ -83,6 +107,33 @@ public struct MyPetFeature {
       }
     }
     .forEach(\.path, action: \.path)
+  }
+}
+
+extension MyPetFeature {
+  func fetchMyPetInfoEffect(
+    _ useCase: CheckPetInfoUseCase
+  ) -> Effect<Action> {
+    .run { send in
+      do {
+        /// 캐시 키 생성
+        let cacheKey = MyPetCacheKey.myPetInfo
+        
+        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
+        if let hitData = await cache.value(forKey: cacheKey) {
+          /// 캐시 hit되면 그대로 사용
+          let entity = PetInfoEntity(hitData)
+          await send(.fetchMyPetInfoResult(.success(entity)))
+        }
+        /// 캐시 miss되면 API 호출
+        let entity = try await useCase.execute()
+        await send(.fetchMyPetInfoResult(.success(entity)))
+      } catch is CancellationError {
+        await send(.fetchMyPetInfoResult(.failure(.taskCancelled)))
+      } catch {
+        await send(.fetchMyPetInfoResult(.failure(.customError(message: error.localizedDescription))))
+      }
+    }
   }
 }
 

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -19,7 +19,7 @@ public struct CatCardCell: View {
   }
   
   public var body: some View {
-    RoundedRectangle(cornerRadius: 12)
+    RoundedRectangle(cornerRadius: .Number8)
       .fill(card.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
       .frame(width: .Number64, height: .Number64)
       .overlay(
@@ -31,11 +31,9 @@ public struct CatCardCell: View {
               renderingMode: .template,
               color: ColorSet.Icon.Tertiary
             )
-          } else {
-            RoundedRectangle(cornerRadius: 12)
-              .fill(ColorSet.Component.Primary.opacity(0.2))
           }
         }
       )
+      .opacity(card.isLocked ? 0.4 : 1.0)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -1,0 +1,41 @@
+//
+//  CatCardCell.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import DesignKit
+
+public struct CatCardCell: View {
+  public let card: CatCard
+  
+  public init(
+    card: CatCard
+  ) {
+    self.card = card
+  }
+  
+  public var body: some View {
+    RoundedRectangle(cornerRadius: 12)
+      .fill(card.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
+      .frame(width: .Number64, height: .Number64)
+      .overlay(
+        Group {
+          if card.isLocked {
+            Icon(
+              image: .lock,
+              size: .Number24,
+              renderingMode: .template,
+              color: ColorSet.Icon.Tertiary
+            )
+          } else {
+            RoundedRectangle(cornerRadius: 12)
+              .fill(ColorSet.Component.Primary.opacity(0.2))
+          }
+        }
+      )
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -1,0 +1,72 @@
+//
+//  GrowthRecordCell.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import DesignKit
+
+public struct GrowthRecordCell: View {
+  public let record: GrowthRecord
+  
+  public init(
+    record: GrowthRecord
+  ) {
+    self.record = record
+  }
+  
+  public var body: some View {
+    HStack(spacing: 16) {
+      // 썸네일 이미지
+      RoundedRectangle(cornerRadius: 8)
+        .fill(record.isLocked ? ColorSet.Background.Tertiary : ColorSet.Background.Secondary)
+        .frame(width: 60, height: 60)
+        .overlay(
+          Group {
+            if record.isLocked {
+              Icon(
+                image: .lock,
+                size: .Number24,
+                renderingMode: .template,
+                color: ColorSet.Icon.Tertiary
+              )
+            } else {
+              RoundedRectangle(cornerRadius: 8)
+                .fill(ColorSet.Component.Primary.opacity(0.2))
+            }
+          }
+        )
+      
+      // 정보 영역
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 6) {
+          Text(record.level)
+            .font(FontSet.Caption.caption1)
+            .foregroundColor(ColorSet.Text.Tertiary)
+          
+          Text(record.title)
+            .font(FontSet.Body.body2)
+            .foregroundColor(ColorSet.Text.Primary)
+            .lineLimit(1)
+        }
+        
+        Text(record.date)
+          .font(FontSet.Caption.caption1)
+          .foregroundColor(ColorSet.Text.Tertiary)
+      }
+      
+      Spacer()
+      
+      // 쓰담 수
+      Text(record.stampCount)
+        .font(FontSet.Body.body3)
+        .foregroundColor(ColorSet.Text.Secondary)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .opacity(record.isLocked ? 0.5 : 1.0)
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -67,6 +67,6 @@ public struct GrowthRecordCell: View {
     }
     .padding(.horizontal, .Number16)
     .padding(.vertical, .Number8)
-    .opacity(record.isLocked ? 0.5 : 1.0)
+    .opacity(record.isLocked ? 0.4 : 1.0)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -19,54 +19,54 @@ public struct GrowthRecordCell: View {
   }
   
   public var body: some View {
-    HStack(spacing: 16) {
-      // 썸네일 이미지
-      RoundedRectangle(cornerRadius: 8)
-        .fill(record.isLocked ? ColorSet.Background.Tertiary : ColorSet.Background.Secondary)
-        .frame(width: 60, height: 60)
-        .overlay(
-          Group {
-            if record.isLocked {
-              Icon(
-                image: .lock,
-                size: .Number24,
-                renderingMode: .template,
-                color: ColorSet.Icon.Tertiary
-              )
-            } else {
-              RoundedRectangle(cornerRadius: 8)
-                .fill(ColorSet.Component.Primary.opacity(0.2))
+    HStack(alignment: .center, spacing: .Number16) {
+      HStack(alignment: .center, spacing: .Number12) {
+        // 썸네일 이미지
+        RoundedRectangle(cornerRadius: .Number8)
+          .fill(record.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
+          .frame(width: .Number64, height: .Number64)
+          .overlay(
+            Group {
+              if record.isLocked {
+                Icon(
+                  image: .lock,
+                  size: .Number24,
+                  renderingMode: .template,
+                  color: ColorSet.Icon.Tertiary
+                )
+              }
             }
+          )
+        
+        // 정보 영역
+        VStack(alignment: .leading, spacing: .Number4) {
+          HStack(alignment: .center, spacing: .Number6) {
+            Badge(text: .constant(record.level), state: .primary)
+            
+            Text(record.title)
+              .font(FontSet.Body.body2)
+              .foregroundColor(ColorSet.Text.Primary)
+              .lineLimit(1)
           }
-        )
-      
-      // 정보 영역
-      VStack(alignment: .leading, spacing: 4) {
-        HStack(spacing: 6) {
-          Text(record.level)
-            .font(FontSet.Caption.caption1)
-            .foregroundColor(ColorSet.Text.Tertiary)
           
-          Text(record.title)
-            .font(FontSet.Body.body2)
-            .foregroundColor(ColorSet.Text.Primary)
-            .lineLimit(1)
+          if let date = record.date {
+            Text(date)
+              .font(FontSet.Caption.caption1)
+              .foregroundColor(ColorSet.Text.Tertiary)
+          }
+          
         }
         
-        Text(record.date)
-          .font(FontSet.Caption.caption1)
-          .foregroundColor(ColorSet.Text.Tertiary)
+        Spacer()
       }
-      
-      Spacer()
       
       // 쓰담 수
       Text(record.stampCount)
-        .font(FontSet.Body.body3)
-        .foregroundColor(ColorSet.Text.Secondary)
+        .font(FontSet.Caption.caption1)
+        .foregroundColor(ColorSet.Text.Tertiary)
     }
-    .padding(.horizontal, 16)
-    .padding(.vertical, 12)
+    .padding(.horizontal, .Number16)
+    .padding(.vertical, .Number8)
     .opacity(record.isLocked ? 0.5 : 1.0)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatCard.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatCard.swift
@@ -1,0 +1,15 @@
+//
+//  CatCardModel.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct CatCard: Identifiable {
+  public let id = UUID()
+  public let image: String? // nil이면 잠긴 상태
+  public let isLocked: Bool
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
@@ -13,7 +13,7 @@ public struct GrowthRecord: Identifiable {
   public let level: String
   public let title: String
   public let description: String
-  public let date: String
+  public let date: String?
   public let stampCount: String
   public let isLocked: Bool
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
@@ -1,0 +1,19 @@
+//
+//  GrowthRecord.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct GrowthRecord: Identifiable {
+  public let id = UUID()
+  public let level: String
+  public let title: String
+  public let description: String
+  public let date: String
+  public let stampCount: String
+  public let isLocked: Bool
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
@@ -11,7 +11,7 @@ import DesignKit
 
 public struct MyPetCardView: View {
   
-  private let level: String
+  private let level: Int
   private let petNickName: String
   private let nextLevelText: String
   private let currentStamps: Int
@@ -29,9 +29,9 @@ public struct MyPetCardView: View {
     goalStamp: Int,
     _ action: @escaping @Sendable () -> Void
   ) {
-    self.level = "Lv.\(level)"
+    self.level = level
     self.petNickName = petNickName
-    self.nextLevelText = "다음 레벨까지 \(goalStamp - currentStamps)쓰담"
+    self.nextLevelText = level == 5 ? "최대 레벨을 달성했습니다 🎉" : "다음 레벨까지 \(goalStamp - currentStamps)쓰담"
     self.currentStamps = currentStamps
     self.goalStamp = goalStamp
     self.action = action
@@ -41,7 +41,7 @@ public struct MyPetCardView: View {
     VStack(alignment: .leading, spacing: .Number4) {
       /// --------- 헤더 영역 ---------
       HStack(spacing: .Number6) {
-        Badge(text: .constant(level), state: .primary)
+        Badge(text: .constant("Lv.\(level)"), state: .primary)
         Text(petNickName)
           .font(FontSet.Heading.heading3)
           .foregroundStyle(ColorSet.Text.Primary)
@@ -84,7 +84,7 @@ public struct MyPetCardView: View {
         }
         .frame(height: .Number6)
         
-        Text("\(currentStamps) / \(goalStamp) 쓰담")
+        Text( level == 5 ? "Max" : "\(currentStamps) / \(goalStamp) 쓰담")
           .font(FontSet.Body.body3)
           .foregroundStyle(ColorSet.Text.Primary)
       }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import DesignKit
+import PetDomainInterface
 
 public struct MyPetCardView: View {
   
@@ -16,28 +17,35 @@ public struct MyPetCardView: View {
   private let nextLevelText: String
   private let currentStamps: Int
   private let goalStamp: Int
+  private let myPetInfo :PetInfoEntity?
   
   public var action: @Sendable () -> Void
-  
   
   @State private var progress: CGFloat = 0.0
   
   public init(
-    level: Int,
-    petNickName: String,
-    currentStamps: Int,
-    goalStamp: Int,
+    myPetInfo: PetInfoEntity?,
     _ action: @escaping @Sendable () -> Void
   ) {
-    self.level = level
-    self.petNickName = petNickName
+    self.level = myPetInfo?.levelType.transformed ?? 0
+    self.petNickName = myPetInfo?.nickname ?? "서버 오류 냥이"
+    self.currentStamps = myPetInfo?.currentPoint ?? 0
+    self.goalStamp = myPetInfo?.goalPoint ?? 0
     self.nextLevelText = level == 5 ? "최대 레벨을 달성했습니다 🎉" : "다음 레벨까지 \(goalStamp - currentStamps)쓰담"
-    self.currentStamps = currentStamps
-    self.goalStamp = goalStamp
     self.action = action
+    self.myPetInfo = myPetInfo
   }
   
   public var body: some View {
+    ContentView
+    
+    //TODO: - 서버 오류로 인해 펫 정보가 없는 경우 뭘 보여줘야할까
+    if myPetInfo != nil {  }
+    else {  }
+  }
+  
+  @ViewBuilder
+  private var ContentView: some View {
     VStack(alignment: .leading, spacing: .Number4) {
       /// --------- 헤더 영역 ---------
       HStack(spacing: .Number6) {
@@ -93,8 +101,9 @@ public struct MyPetCardView: View {
     .background(ColorSet.Background.Primary)
     .cornerRadius(.Number16)
     .elevation(level: .medium, cornerRadius: .Number16)
-    .onAppear {
+    .onChange(of: myPetInfo) { _, _ in
       withAnimation(.easeInOut(duration: 1.0)) {
+        print("Current Stamps: \(currentStamps), Goal Stamp: \(goalStamp) || Progress: \(progress)")
         progress = goalStamp > 0 ? CGFloat(currentStamps) / CGFloat(goalStamp) : 0.0
       }
     }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
@@ -38,6 +38,5 @@ public struct MyPetDetailView: View {
         }
       }
     )
-    .blockBackToSwipe()
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
@@ -1,0 +1,78 @@
+//
+//  MyPetGrowthListView.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/16/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import DesignKit
+
+public struct BigBottomSheetContentView: View {
+  // 샘플 데이터
+  
+  private let catCards: [CatCard]
+  private let growthRecords: [GrowthRecord]
+  
+  @Binding private var startBottomSheetInsideScroll: Bool
+  @Binding private var bottomSheetDragEnabled: Bool
+  
+  public init(
+    catCards: [CatCard],
+    growthRecords: [GrowthRecord],
+    startBottomSheetInsideScroll: Binding<Bool>,
+    bottomSheetDragEnabled: Binding<Bool>
+  ) {
+    self.catCards = catCards
+    self.growthRecords = growthRecords
+    self._startBottomSheetInsideScroll = startBottomSheetInsideScroll
+    self._bottomSheetDragEnabled = bottomSheetDragEnabled
+  }
+  
+  public var body: some View {
+    VStack(alignment: .center) {
+      // 고양이 카드 가로 스크롤
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: .Number12) {
+          ForEach(catCards) { CatCardCell(card: $0) }
+        }
+        .padding(.horizontal, .Number16)
+        .padding(.vertical, .Number12)
+      }
+      .simultaneousGesture(
+        DragGesture()
+          .onChanged { value in
+            if startBottomSheetInsideScroll {
+              let horizontalAmount = abs(value.translation.width) > 10 ? abs(value.translation.width) : 0
+              let verticalAmount = abs(value.translation.height) > 10 ? abs(value.translation.height) : 0
+              bottomSheetDragEnabled = verticalAmount > horizontalAmount
+              startBottomSheetInsideScroll = false
+            }
+          }
+          .onEnded { _ in
+            startBottomSheetInsideScroll = true
+            bottomSheetDragEnabled = true
+          }
+      )
+      
+      // 성장 기록 섹션 헤더
+      HStack(alignment: .center) {
+        Text("성장 기록")
+          .font(FontSet.Body.body3)
+          .foregroundColor(ColorSet.Text.Secondary)
+          .padding(.horizontal, .Number16)
+        Spacer()
+      }
+      .padding(.top, .Number8)
+      
+      // 성장 기록 리스트 (스크롤 가능)
+      ScrollView(.vertical, showsIndicators: false) {
+        VStack {
+          ForEach(growthRecords) { GrowthRecordCell(record: $0) }
+        }
+      }
+    }
+    .padding(.vertical, .Number8)
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
@@ -56,6 +56,9 @@ public struct BigBottomSheetContentView: View {
           }
       )
       
+      BorderView(size: .long)
+        .padding(.horizontal, .Number16)
+      
       // 성장 기록 섹션 헤더
       HStack(alignment: .center) {
         Text("성장 기록")

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -52,14 +52,17 @@ public struct MyPetView: View {
   private var ContentView: some View {
     if store.isLoggedIn {
       ZStack {
-        MainView
-        CustomBottomSheet(
-          minHeight: .Number72,
-          midHeight: .Number100,
-          isBottomSheetDragEnabled: $bottomSheetDragEnabled,
-          smallContent: { SmallBottomSheetContent },
-          largeContent: { BigBottomSheetContent }
-        )
+        GeometryReader { proxy in
+          MainView
+          CustomBottomSheet(
+            minHeight: .Number72,
+            maxHeight: proxy.size.height,
+            midHeight: .Number100,
+            isBottomSheetDragEnabled: $bottomSheetDragEnabled,
+            smallContent: { SmallBottomSheetContent },
+            largeContent: { BigBottomSheetContent }
+          )
+        }
       }
       .padding(.bottom, 50)
     }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -104,7 +104,7 @@ public struct MyPetView: View {
   @ViewBuilder
   private var CommonHeaderView: some View {
     HStack(alignment: .center) {
-      Text("내가 살린 고양이")
+      Text("내가 돌본 고양이")
         .font(FontSet.Body.body3)
         .foregroundStyle(ColorSet.Text.Secondary)
         .padding(.horizontal, .Number16)

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -74,34 +74,7 @@ public struct MyPetView: View {
       VStack {
         CardView
           .padding(.Number16)
-        /// 일단 더미데이터 로 채워둠
-        ZStack {
-          VStack {
-            Spacer()
-            
-            // 펫 이미지 (임시로 원형 뷰)
-            Circle()
-              .fill(Color.orange.opacity(0.7))
-              .frame(width: 150, height: 150)
-              .overlay(
-                VStack {
-                  Circle()
-                    .fill(Color.black)
-                    .frame(width: 4, height: 4)
-                    .offset(x: -15, y: -10)
-                  Circle()
-                    .fill(Color.black)
-                    .frame(width: 4, height: 4)
-                    .offset(x: 15, y: -30)
-                  Circle()
-                    .fill(ColorSet.Background.Secondary)
-                    .frame(width: 12, height: 8)
-                    .offset(y: 5)
-                }
-              )
-            Spacer()
-          }
-        }
+        Spacer()
       }
     }
     .background(ColorSet.Background.Accent)
@@ -131,17 +104,10 @@ public struct MyPetView: View {
   // MARK: - 더미데이터로 주입한 카드 뷰
   @ViewBuilder
   private var CardView: some View {
-    if let myPetInfo = store.myPetInfo {
-      MyPetCardView(
-        level: myPetInfo.levelType.transformed,
-        petNickName: myPetInfo.nickname,
-        currentStamps: myPetInfo.currentPoint,
-        goalStamp: myPetInfo.goalPoint
-      ) {
-        store.send(.petNicknameButtonTapped)
-      }
-    } else {
-      EmptyView()
+    MyPetCardView(
+      myPetInfo: store.myPetInfo
+    ) {
+      store.send(.petNicknameButtonTapped)
     }
   }
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -53,11 +53,7 @@ public struct MyPetView: View {
         CustomBottomSheet(
           minHeight: .Number72,
           midHeight: .Number200,
-          smallContent: {
-            Text("작은 시트")
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
-              .background(Color.yellow)
-          },
+          smallContent: { SmallBottomSheetContent },
           largeContent: {
             Text("큰 시트")
               .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -74,43 +70,58 @@ public struct MyPetView: View {
   
   @ViewBuilder
   private var MainView: some View {
-    
-    VStack(spacing: 0) {
-      // 상단 카드 뷰
-      CardView
-        .padding(.Number16)
-      // 중간 펫 이미지 영역
-      ZStack {
-        // 배경색 (연한 파란색)
-        ColorSet.Background.Accent
-          .ignoresSafeArea()
-        
-        VStack {
-          Spacer()
-          
-          // 펫 이미지 (임시로 원형 뷰)
-          Circle()
-            .fill(Color.orange.opacity(0.7))
-            .frame(width: 150, height: 150)
-            .overlay(
-              VStack {
-                Circle()
-                  .fill(Color.black)
-                  .frame(width: 4, height: 4)
-                  .offset(x: -15, y: -10)
-                Circle()
-                  .fill(Color.black)
-                  .frame(width: 4, height: 4)
-                  .offset(x: 15, y: -30)
-                Circle()
-                  .fill(ColorSet.Background.Secondary)
-                  .frame(width: 12, height: 8)
-                  .offset(y: 5)
-              }
-            )
-          Spacer()
+    ZStack {
+      VStack {
+        CardView
+          .padding(.Number16)
+        /// 일단 더미데이터 로 채워둠
+        ZStack {
+          VStack {
+            Spacer()
+            
+            // 펫 이미지 (임시로 원형 뷰)
+            Circle()
+              .fill(Color.orange.opacity(0.7))
+              .frame(width: 150, height: 150)
+              .overlay(
+                VStack {
+                  Circle()
+                    .fill(Color.black)
+                    .frame(width: 4, height: 4)
+                    .offset(x: -15, y: -10)
+                  Circle()
+                    .fill(Color.black)
+                    .frame(width: 4, height: 4)
+                    .offset(x: 15, y: -30)
+                  Circle()
+                    .fill(ColorSet.Background.Secondary)
+                    .frame(width: 12, height: 8)
+                    .offset(y: 5)
+                }
+              )
+            Spacer()
+          }
         }
       }
+    }
+    .background(ColorSet.Background.Accent)
+  }
+  
+  @ViewBuilder
+  private var SmallBottomSheetContent: some View {
+    HStack(alignment: .center) {
+      Text("내가 살린 고양이")
+        .font(FontSet.Body.body3)
+        .foregroundStyle(ColorSet.Text.Secondary)
+        .padding(.horizontal, .Number16)
+      Spacer()
+      TouchArea(
+        image: .rightChevron,
+        size: .Number24
+      ) {
+        store.send(.petDetailButtonTapped)
+      }
+      .padding(.trailing, .Number8)
     }
   }
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -115,13 +115,16 @@ public struct MyPetView: View {
         .foregroundStyle(ColorSet.Text.Secondary)
         .padding(.horizontal, .Number16)
       Spacer()
-      TouchArea(
+      Icon(
         image: .rightChevron,
-        size: .Number24
-      ) {
-        store.send(.petDetailButtonTapped)
-      }
+        size: .Number24,
+        renderingMode: .template,
+        color: ColorSet.Icon.Primary
+      )
       .padding(.trailing, .Number8)
+    }
+    .onTapGesture {
+      store.send(.petDetailButtonTapped)
     }
   }
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -13,6 +13,9 @@ import DesignKit
 public struct MyPetView: View {
   @Bindable var store: StoreOf<MyPetFeature>
   
+  @State private var bottomSheetDragEnabled: Bool = true
+  @State private var startBottomSheetInsideScroll: Bool = true
+    
   public init(store: StoreOf<MyPetFeature>) {
     self.store = store
   }
@@ -52,7 +55,8 @@ public struct MyPetView: View {
         MainView
         CustomBottomSheet(
           minHeight: .Number72,
-          midHeight: .Number200,
+          midHeight: .Number100,
+          isBottomSheetDragEnabled: $bottomSheetDragEnabled,
           smallContent: { SmallBottomSheetContent },
           largeContent: { BigBottomSheetContent }
         )
@@ -109,6 +113,21 @@ public struct MyPetView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
       }
+      .simultaneousGesture(
+        DragGesture()
+          .onChanged { value in
+            if startBottomSheetInsideScroll {
+              let horizontalAmount = abs(value.translation.width) > 10 ? abs(value.translation.width) : 0
+              let verticalAmount = abs(value.translation.height) > 10 ? abs(value.translation.height) : 0
+              bottomSheetDragEnabled = verticalAmount > horizontalAmount
+              startBottomSheetInsideScroll = false
+            }
+          }
+          .onEnded { _ in
+            startBottomSheetInsideScroll = true
+            bottomSheetDragEnabled = true
+          }
+      )
       
       // 성장 기록 섹션 헤더
       Text("성장 기록")

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -54,11 +54,7 @@ public struct MyPetView: View {
           minHeight: .Number72,
           midHeight: .Number200,
           smallContent: { SmallBottomSheetContent },
-          largeContent: {
-            Text("큰 시트")
-              .frame(maxWidth: .infinity, maxHeight: .infinity)
-              .background(Color.yellow)
-          }
+          largeContent: { BigBottomSheetContent }
         )
       }
       .padding(.bottom, 50)
@@ -81,7 +77,69 @@ public struct MyPetView: View {
   }
   
   @ViewBuilder
+  private var BigBottomSheetContent: some View {
+    let catCards = [
+      CatCard(image: "cat1", isLocked: false),
+      CatCard(image: "cat2", isLocked: false),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true),
+      CatCard(image: nil, isLocked: true)
+    ]
+    
+    let growthRecords = [
+      GrowthRecord(level: "Lv.1", title: "작고 소중한 {{고양이 이름}}", description: "", date: "YY.MM.DD.", stampCount: "0쓰담", isLocked: false),
+      GrowthRecord(level: "Lv.2", title: "호기심 가득한 {{고양이 이...", description: "", date: "YY.MM.DD.", stampCount: "20쓰담", isLocked: false),
+      GrowthRecord(level: "Lv.3", title: "쑥쑥 자라나는 {{고양이...", description: "", date: "", stampCount: "110쓰담", isLocked: true),
+      GrowthRecord(level: "Lv.4", title: "왕 커서 귀여운{{고양이 이...", description: "", date: "", stampCount: "N쓰담", isLocked: true),
+      GrowthRecord(level: "Special", title: "{{스페셜 문구}} {{고양이...", description: "", date: "", stampCount: "N쓰담", isLocked: true)
+    ]
+    
+    
+    VStack(alignment: .center) {
+      CommonHeaderView
+      
+      // 고양이 카드 가로 스크롤
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 12) {
+          ForEach(catCards) { card in
+            CatCardCell(card: card)
+          }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+      }
+      
+      // 성장 기록 섹션 헤더
+      Text("성장 기록")
+        .font(FontSet.Body.body2)
+        .foregroundColor(ColorSet.Text.Primary)
+        .padding(.horizontal, 16)
+        .padding(.top, 16)
+        .padding(.bottom, 12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+      
+      // 성장 기록 리스트 (스크롤 가능)
+      ScrollView(.vertical, showsIndicators: false) {
+        LazyVStack(spacing: 0) {
+          ForEach(growthRecords) { record in
+            VStack(spacing: 0) {
+              GrowthRecordCell(record: record)
+            }
+          }
+        }
+      }
+    }
+    .padding(.vertical, .Number8)
+  }
+  
+  @ViewBuilder
   private var SmallBottomSheetContent: some View {
+    CommonHeaderView
+  }
+  
+  @ViewBuilder
+  private var CommonHeaderView: some View {
     HStack(alignment: .center) {
       Text("내가 살린 고양이")
         .font(FontSet.Body.body3)

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -57,7 +57,7 @@ public struct MyPetView: View {
           CustomBottomSheet(
             minHeight: .Number72,
             maxHeight: proxy.size.height,
-            midHeight: .Number100,
+            midHeight: .Number200,
             isBottomSheetDragEnabled: $bottomSheetDragEnabled,
             smallContent: { SmallBottomSheetContent },
             largeContent: { BigBottomSheetContent }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -131,13 +131,17 @@ public struct MyPetView: View {
   // MARK: - 더미데이터로 주입한 카드 뷰
   @ViewBuilder
   private var CardView: some View {
-    MyPetCardView(
-      level: 1,
-      petNickName: "작고 소중한" + "{{고양이 이름}}",
-      currentStamps: 10,
-      goalStamp: 100
-    ) {
-      store.send(.petNicknameButtonTapped)
+    if let myPetInfo = store.myPetInfo {
+      MyPetCardView(
+        level: myPetInfo.levelType.transformed,
+        petNickName: myPetInfo.nickname,
+        currentStamps: myPetInfo.currentPoint,
+        goalStamp: myPetInfo.goalPoint
+      ) {
+        store.send(.petNicknameButtonTapped)
+      }
+    } else {
+      EmptyView()
     }
   }
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -82,74 +82,15 @@ public struct MyPetView: View {
   
   @ViewBuilder
   private var BigBottomSheetContent: some View {
-    let catCards = [
-      CatCard(image: "cat1", isLocked: false),
-      CatCard(image: "cat2", isLocked: false),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true)
-    ]
-    
-    let growthRecords = [
-      GrowthRecord(level: "Lv.1", title: "작고 소중한 {{고양이 이름}}", description: "", date: "YY.MM.DD.", stampCount: "0쓰담", isLocked: false),
-      GrowthRecord(level: "Lv.2", title: "호기심 가득한 {{고양이 이...", description: "", date: "YY.MM.DD.", stampCount: "20쓰담", isLocked: false),
-      GrowthRecord(level: "Lv.3", title: "쑥쑥 자라나는 {{고양이...", description: "", date: "", stampCount: "110쓰담", isLocked: true),
-      GrowthRecord(level: "Lv.4", title: "왕 커서 귀여운{{고양이 이...", description: "", date: "", stampCount: "N쓰담", isLocked: true),
-      GrowthRecord(level: "Special", title: "{{스페셜 문구}} {{고양이...", description: "", date: "", stampCount: "N쓰담", isLocked: true)
-    ]
-    
-    
-    VStack(alignment: .center) {
+    VStack {
       CommonHeaderView
-      
-      // 고양이 카드 가로 스크롤
-      ScrollView(.horizontal, showsIndicators: false) {
-        HStack(spacing: 12) {
-          ForEach(catCards) { card in
-            CatCardCell(card: card)
-          }
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 16)
-      }
-      .simultaneousGesture(
-        DragGesture()
-          .onChanged { value in
-            if startBottomSheetInsideScroll {
-              let horizontalAmount = abs(value.translation.width) > 10 ? abs(value.translation.width) : 0
-              let verticalAmount = abs(value.translation.height) > 10 ? abs(value.translation.height) : 0
-              bottomSheetDragEnabled = verticalAmount > horizontalAmount
-              startBottomSheetInsideScroll = false
-            }
-          }
-          .onEnded { _ in
-            startBottomSheetInsideScroll = true
-            bottomSheetDragEnabled = true
-          }
+      BigBottomSheetContentView(
+        catCards: store.catCards,
+        growthRecords: store.growthRecords,
+        startBottomSheetInsideScroll: $startBottomSheetInsideScroll,
+        bottomSheetDragEnabled: $bottomSheetDragEnabled
       )
-      
-      // 성장 기록 섹션 헤더
-      Text("성장 기록")
-        .font(FontSet.Body.body2)
-        .foregroundColor(ColorSet.Text.Primary)
-        .padding(.horizontal, 16)
-        .padding(.top, 16)
-        .padding(.bottom, 12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-      
-      // 성장 기록 리스트 (스크롤 가능)
-      ScrollView(.vertical, showsIndicators: false) {
-        LazyVStack(spacing: 0) {
-          ForEach(growthRecords) { record in
-            VStack(spacing: 0) {
-              GrowthRecordCell(record: record)
-            }
-          }
-        }
-      }
     }
-    .padding(.vertical, .Number8)
   }
   
   @ViewBuilder


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #46 

## 🔎 작업 내용
- 마이펫 페이지의 바텀시트에 들어가는 UI를 구현했습니다.
- 현재 내부 데이터는 더미데이터로 작성되어있습니다.
- 마이펫 페이지 메인에서 확인할 수 있는 마이펫 카드의 정보는 Cache 기반으로 동작합니다.
  - 이후에 Cache를 활용해야 할 경우가 있다면 확인해보시면 될 듯
- 바텀시트에는 총 3개의 gesture가 엮여있는 상태라, 별도의 우선순위를 잡아서 처리했습니다.
  - 가로 스크롤뷰를 동작하는 과정에서 바텀시트의 드래그 허용 여부
  - 수직 스크롤뷰를 동작하는 과정에서 바텀시트의 드래그 허용 여부 등 등.... 
## 📷 스크린샷

https://github.com/user-attachments/assets/f7a650de-c3c0-4cf0-8a57-1175e8880a59


## 🛠️ 기타 공유 내용
- 데이터 연결은 merge되면 진행 예정.
- 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added caching for pet information to improve performance and reduce network requests.
  * Introduced new UI components: CatCardCell, GrowthRecordCell, and BigBottomSheetContentView for enhanced pet and growth record visualization.
  * Added support for displaying cat cards and growth records in the MyPet feature.
  * Enabled fetching and displaying detailed pet info within the MyPet feature.

* **Enhancements**
  * Refined MyPetCardView and MyPetView to use unified pet info entities and modularized bottom sheet content.
  * Made the bottom sheet drag behavior dynamically controllable for improved user interaction.

* **Bug Fixes**
  * Restored swipe-back navigation in MyPetDetailView by removing the block on swipe gestures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->