### PR TITLE
Bug/#48 회의에 논의된 수정사항 적용

### DIFF
--- a/Projects/Data/NMReverseGeocoding/NMReverseGeocodingDataInterface/Sources/Body/NMReverseGeoCodeQuery.swift
+++ b/Projects/Data/NMReverseGeocoding/NMReverseGeocodingDataInterface/Sources/Body/NMReverseGeoCodeQuery.swift
@@ -17,7 +17,7 @@ public struct NMReverseGeoCodeQuery: Codable {
   
   public init(_ input: NMReverseGeoCodeInput) {
     self.coords = "\(input.longitude),\(input.latitude)"
-    self.orders = "roadaddr"
+    self.orders = "admcode,legalcode,addr,roadaddr"
     self.output = "json"
   }
 }

--- a/Projects/Data/NMReverseGeocoding/NMReverseGeocodingDataInterface/Sources/DTO/NMReverseGeoCodeDTO.swift
+++ b/Projects/Data/NMReverseGeocoding/NMReverseGeocodingDataInterface/Sources/DTO/NMReverseGeoCodeDTO.swift
@@ -18,10 +18,19 @@ public struct NMReverseGeoCodeDTO: DTO {
   public let results: [Result]
   
   public struct Result: Decodable & Sendable {
+    public let name: String?
+    public let code: Code?
     public let region: Region
     public let land: Land?
     
+    public struct Code: Decodable & Sendable {
+      public let id: String
+      public let type: String
+      public let mappingId: String
+    }
+    
     public struct Region: Decodable & Sendable {
+      public let area0: Area?
       public let area1: Area
       public let area2: Area
       public let area3: Area
@@ -30,13 +39,26 @@ public struct NMReverseGeoCodeDTO: DTO {
     
     public struct Area: Decodable & Sendable {
       public let name: String
+      public let coords: Coords?
       public let alias: String?
+      
+      public struct Coords: Decodable & Sendable {
+        public let center: Center
+        
+        public struct Center: Decodable & Sendable {
+          public let crs: String
+          public let x: Double
+          public let y: Double
+        }
+      }
     }
     
     public struct Land: Decodable & Sendable {
+      public let type: String?         // "" or "지번주소"
       public let name: String?         // 도로명
       public let number1: String?      // 건물 번호
       public let number2: String?      // 건물 부번호 (ex: -2)
+      public let coords: Coords?
       public let addition0: Addition?  // type: building
       public let addition1: Addition?  // type: zipcode
       public let addition2: Addition?  // type: roadGroupCode
@@ -47,33 +69,111 @@ public struct NMReverseGeoCodeDTO: DTO {
         public let type: String?
         public let value: String?
       }
+      
+      public struct Coords: Decodable & Sendable {
+        public let center: Center
+        
+        public struct Center: Decodable & Sendable {
+          public let crs: String
+          public let x: Double
+          public let y: Double
+        }
+      }
     }
   }
 }
 
+// MARK: - Priority Logic
 extension NMReverseGeoCodeDTO {
+  
+  /// 우선순위에 따른 결과 선택
+  /// 1. 도로명 주소 (land.type이 nil 또는 빈 문자열)
+  /// 2. 행정동 (name이 존재하고 land가 nil)
+  /// 3. 지번주소 (land.type이 "지번주소")
+  private func selectBestResult() -> Result? {
+    // 1순위: 도로명 주소 찾기
+    if let roadAddressResult = results.first(where: { result in
+      result.land != nil && (result.land?.type == nil || result.land?.type == "")
+    }) {
+      return roadAddressResult
+    }
+    
+    // 2순위: 행정동 찾기
+    if let adminResult = results.first(where: { result in
+      result.name != nil && result.land == nil
+    }) {
+      return adminResult
+    }
+    
+    // 3순위: 지번주소 찾기
+    if let jibunResult = results.first(where: { result in
+      result.land?.type == "지번주소"
+    }) {
+      return jibunResult
+    }
+    
+    // 우선순위에 맞는 결과가 없으면 첫 번째 결과 반환
+    return results.first
+  }
+  
   public func toEntity() throws -> NMGeoCodeReverseEntity {
-    guard let result = results.first else {
+    guard let bestResult = selectBestResult() else {
       throw NetworkError.customError(message: "지도 역변환 결과 데이터가 없습니다.")
     }
     
     // 행정구역 정보
-    let area1 = result.region.area1.name
-    let area2 = result.region.area2.name
-    let area3 = result.region.area3.name
-    let area4 = result.region.area4?.name
+    let area1 = bestResult.region.area1.name
+    let area2 = bestResult.region.area2.name
+    let area3 = bestResult.region.area3.name
+    let area4 = bestResult.region.area4?.name
     
-    // 도로명 주소 조합
-    let roadName = result.land?.name
-    let number1 = result.land?.number1
-    let buildingName = result.land?.addition0?.type == "building" ? result.land?.addition0?.value : nil
-    let zipCode = result.land?.addition1?.type == "zipcode" ? result.land?.addition1?.value : nil
+    // 주소 조합
+    var roadAddress: String
+    var zipCode: String?
     
-    let fullRoadAddress = [area1, area2, roadName, number1]
-      .compactMap { $0 }
-      .joined(separator: " ")
-    
-    let roadAddress = buildingName != nil ? "\(fullRoadAddress) (\(buildingName!))" : fullRoadAddress
+    if let land = bestResult.land {
+      // 도로명 또는 지번주소가 있는 경우
+      let roadName = land.name
+      let number1 = land.number1
+      let number2 = land.number2
+      
+      // 건물명 찾기
+      let buildingName = land.addition0?.type == "building" ? land.addition0?.value : nil
+      
+      // 우편번호 찾기
+      zipCode = [land.addition0, land.addition1, land.addition2, land.addition3, land.addition4]
+        .compactMap { $0 }
+        .first(where: { $0.type == "zipcode" })?
+        .value
+      
+      // 주소 조합
+      var addressComponents = [area1, area2]
+      
+      if let roadName = roadName {
+        addressComponents.append(roadName)
+      }
+      
+      if let number1 = number1 {
+        if let number2 = number2, !number2.isEmpty {
+          addressComponents.append("\(number1)-\(number2)")
+        } else {
+          addressComponents.append(number1)
+        }
+      }
+      
+      let baseAddress = addressComponents.joined(separator: " ")
+      
+      // 건물명이 있으면 괄호로 추가
+      roadAddress = (buildingName != nil && buildingName != "") ? "\(baseAddress) (\(buildingName!))" : baseAddress
+      
+    } else if let adminName = bestResult.name {
+      // 행정동만 있는 경우
+      let cleanAdminName = adminName.replacingOccurrences(of: "admcode", with: "")
+      roadAddress = [area1, area2, cleanAdminName].joined(separator: " ")
+    } else {
+      // 기본: area3까지 사용
+      roadAddress = [area1, area2, area3].joined(separator: " ")
+    }
     
     return NMGeoCodeReverseEntity(
       area1: area1,

--- a/Projects/Data/Report/ReportDataInterface/Sources/Body/ReportSpotBody.swift
+++ b/Projects/Data/Report/ReportDataInterface/Sources/Body/ReportSpotBody.swift
@@ -12,13 +12,13 @@ import ReportDomainInterface
 public struct ReportSpotBody: Encodable, Equatable {
   public let spotId: Int
   public let reportType: String
-  public let spotName: String
+  public let spotName: String?
   public let latitude: Double?
   public let longitude: Double?
   public let region: String?
   public let city: String?
   public let site: String?
-  public let trashType: String
+  public let trashType: String?
   
   public init(
     _ input: ReportSpotInput

--- a/Projects/Data/Report/ReportDataInterface/Sources/DTO/ReportSpotDTO.swift
+++ b/Projects/Data/Report/ReportDataInterface/Sources/DTO/ReportSpotDTO.swift
@@ -14,7 +14,7 @@ public struct ReportSpotDTO: DTO {
   public typealias Entity = ReportSpotEntity
   
   public let reportId: UInt16
-  public let presignedUrl: String
+  public let presignedUrl: String?
 }
 
 public extension ReportSpotDTO {

--- a/Projects/Domain/Report/ReportDomainInterface/Sources/Entity/ReportSpotEntity.swift
+++ b/Projects/Domain/Report/ReportDomainInterface/Sources/Entity/ReportSpotEntity.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct ReportSpotEntity: Sendable, Equatable {
-  public let imageUploadURL: String
+  public let imageUploadURL: String?
   
-  public init(imageUploadURL: String) {
+  public init(imageUploadURL: String?) {
     self.imageUploadURL = imageUploadURL
   }
 }

--- a/Projects/Domain/Report/ReportDomainInterface/Sources/Input/ReportSpotInput.swift
+++ b/Projects/Domain/Report/ReportDomainInterface/Sources/Input/ReportSpotInput.swift
@@ -13,13 +13,13 @@ import TrashSpotDomainInterface
 public struct ReportSpotInput: Codable, Equatable {
   public let spotId: Int
   public let reportType: String
-  public let spotName: String
+  public let spotName: String?
   public let latitude: Double?
   public let longitude: Double?
   public let region: String?
   public let city: String?
   public let site: String?
-  public let trashType: String
+  public let trashType: String?
   
   public init(
     reportType: String,
@@ -27,12 +27,12 @@ public struct ReportSpotInput: Codable, Equatable {
   ) {
     self.reportType = reportType
     self.spotId = spotDetail?.id ?? 0
-    self.spotName = spotDetail?.spotName ?? ""
+    self.spotName = spotDetail?.spotName
     self.latitude = spotDetail?.latitude
     self.longitude = spotDetail?.longitude
     self.region = spotDetail?.region
     self.city = spotDetail?.city
     self.site = spotDetail?.site
-    self.trashType = spotDetail?.trashType ?? ""
+    self.trashType = spotDetail?.trashType
   }
 }

--- a/Projects/Domain/Report/ReportDomainInterface/Sources/UseCases/ReportSpotUseCase.swift
+++ b/Projects/Domain/Report/ReportDomainInterface/Sources/UseCases/ReportSpotUseCase.swift
@@ -14,13 +14,13 @@ public struct ReportSpotUseCase {
   public var execute: @Sendable (
     _ reportType: String,
     _ trashSpotDetail: TrashSpotFlattenDetailEntity?
-  ) async throws -> String
+  ) async throws -> String?
   
   public init(
     execute: @Sendable @escaping (
       _ reportType: String,
       _ trashSpotDetail: TrashSpotFlattenDetailEntity?
-    ) async throws -> String
+    ) async throws -> String?
   ) {
     self.execute = execute
   }

--- a/Projects/Domain/TrashSpot/TrashSpotDomainInterface/Sources/Entity/TrashSpotFlattenDetailEntity.swift
+++ b/Projects/Domain/TrashSpot/TrashSpotDomainInterface/Sources/Entity/TrashSpotFlattenDetailEntity.swift
@@ -12,23 +12,23 @@ import Utility
 
 public struct TrashSpotFlattenDetailEntity: Equatable, Sendable {
   public var id: Int
-  public var latitude: Double
-  public var longitude: Double
-  public var spotName: String
-  public var region: String
-  public var city: String
-  public var site: String
-  public var trashType: String
+  public var latitude: Double?
+  public var longitude: Double?
+  public var spotName: String?
+  public var region: String?
+  public var city: String?
+  public var site: String?
+  public var trashType: String?
   
   public init(
     id: Int,
-    latitude: Double,
-    longitude: Double,
-    spotName: String,
-    region: String,
-    city: String,
-    site: String,
-    trashType: String
+    latitude: Double? = nil,
+    longitude: Double? = nil,
+    spotName: String? = nil,
+    region: String? = nil,
+    city: String? = nil,
+    site: String? = nil,
+    trashType: String? = nil
   ) {
     self.id = id
     self.latitude = latitude

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -109,7 +109,7 @@ public struct HomeFeature {
         // MARK: - Send Action to HomeRoot
         
       case .suggestionButtonTapped:
-        state.path.append(.suggestionView(SuggestionFeature.State()))
+        state.path.append(.suggestionView(SuggestionFeature.State(state.location.lastCameraPosition)))
         return .send(.delegate(.needToHiddenTabBar(true)))
 
       case let .presentDetailView(isPresent, id):
@@ -151,7 +151,7 @@ public struct HomeFeature {
         
       case let .receiveTrashDetailFromRoot(trashSpotDetail):
         if let detail = trashSpotDetail {
-          state.path.append(.reportView(ReportFeature.State(detail)))
+          state.path.append(.reportView(ReportFeature.State(detail, currentLocation: state.location.lastCameraPosition)))
           return .send(.presentDetailView(false))
         }
         return .none

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/LocationFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/LocationFeature.swift
@@ -22,6 +22,8 @@ public struct LocationFeature {
     /// 초기 이동 여부
     var isInitialMapLoad: Bool = true
     
+    var lastCameraPosition: Coordinates? = nil
+    
     var isCurrentButtonTap: Bool = false
   }
   

--- a/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewCoordinator.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewCoordinator.swift
@@ -55,6 +55,14 @@ extension MapViewRepresentable {
       if isInitialBounds {
         configInitialMove(mapView, requestMapBounds: parent.requestMapBounds)
       }
+      
+      /// 카메라 이동할 때 마다, 좌표 값 저장
+      let target = mapView.cameraPosition.target
+      let center = Coordinates(
+        latitude: target.lat.rounded(to: 6),
+        longitude: target.lng.rounded(to: 6)
+      )
+      Task { @MainActor in parent.lastCameraPosition = center }
     }
     
     

--- a/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
@@ -15,6 +15,8 @@ import CoreGraphics
 
 struct MapViewRepresentable: UIViewRepresentable {
   
+  @Binding var lastCameraPosition: Coordinates?
+  
   @Binding var userLocation: Coordinates?
   /// 현재 지도 범위 요청 플래그
   @Binding var requestMapBounds: Bool

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -70,6 +70,7 @@ public struct HomeView: View {
   @ViewBuilder
   private var MapView: some View {
     MapViewRepresentable(
+      lastCameraPosition: $store.location.lastCameraPosition,
       userLocation: $store.location.point,
       requestMapBounds: $store.map.requestMapBounds,
       trashItems: $store.map.trashItems,

--- a/Projects/Feature/Report/ReportFeature/Sources/Features/ReportChildFeature.swift
+++ b/Projects/Feature/Report/ReportFeature/Sources/Features/ReportChildFeature.swift
@@ -31,10 +31,11 @@ public struct ReportChildFeature {
     
     var trashSpotDetail: TrashSpotDetail
     public init(
-      _ trashSpotDetail: TrashSpotDetail
+      _ trashSpotDetail: TrashSpotDetail,
+      currentLocation: Coordinates? = nil
     ) {
       self.trashSpotDetail = trashSpotDetail
-      self.moveLocation = SelectSpotLocationFeature.State(trashSpotDetail.point) /// 초기값 (선택된 위치) 저장
+      self.moveLocation = SelectSpotLocationFeature.State(currentLocation)
     }
   }
   

--- a/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
+++ b/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
@@ -52,11 +52,12 @@ public struct ReportFeature {
     var reportSpotDetail: TrashSpotFlattenDetailEntity?
     
     public init(
-      _ detail: TrashSpotDetail
+      _ detail: TrashSpotDetail,
+      currentLocation: Coordinates? = nil
     ) {
       self.trashSpotDetail = detail
       self.selectedReportInfo = SelectReportInfoTypeFeature.State()
-      self.child = ReportChildFeature.State(detail)
+      self.child = ReportChildFeature.State(detail, currentLocation: currentLocation)
     }
   }
   

--- a/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
+++ b/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
@@ -70,7 +70,7 @@ public struct ReportFeature {
     case binding(BindingAction<State>)
     
     case combineSpotReportModel
-    case spotReportResult(Result<String, NetworkError>)
+    case spotReportResult(Result<String?, NetworkError>)
     case uploadReportSpotImageResult(Result<String, NetworkError>)
     case postSpotImage(String)
     
@@ -242,8 +242,8 @@ public struct ReportFeature {
         
       case let .spotReportResult(result):
         switch result {
-        case let .success(prisignedURL):
-          if state.selectedReportInfoType == "PHOTO" { return .send(.postSpotImage(prisignedURL)) }
+        case let .success(optionalPresignedURL):
+          if let presignedURL = optionalPresignedURL { return .send(.postSpotImage(presignedURL)) }
           else {
             return .merge([
               .send(.setIsLoading(false)),

--- a/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
+++ b/Projects/Feature/Report/ReportFeature/Sources/Features/ReportFeature.swift
@@ -69,7 +69,6 @@ public struct ReportFeature {
     case child(ReportChildFeature.Action)
     case binding(BindingAction<State>)
     
-    case fetchTrashSpotDetailEffect(Result<TrashSpotFlattenDetailEntity, NetworkError>)
     case combineSpotReportModel
     case spotReportResult(Result<String, NetworkError>)
     case uploadReportSpotImageResult(Result<String, NetworkError>)
@@ -227,28 +226,17 @@ public struct ReportFeature {
         
       case .reportButtonTapped:
         if state.selectedReportInfoType == "NAME" { return .send(.validateSpotNameButtonTapped) }
-        return fetchTrashSpotDetailEffect(state.trashSpotDetail.id, fetchTrashSpotRawDetailUseCase)
+        return .send(.combineSpotReportModel)
         
       case let .postSpotImage(prisignedURL):
         return uploadReportSpotImageEffect(state, prisignedURL, uploadReportSpotImageUseCase)
         
-      case let .fetchTrashSpotDetailEffect(result):
-        switch result {
-        case let .success(entity):
-          state.reportSpotDetail = entity
-          return .send(.combineSpotReportModel)
-        case let .failure(error):
-          state.destination = .alert(.occuredError(error.localizedDescription))
-          return .send(.setIsLoading(false))
-        }
-        
       case .combineSpotReportModel:
-        var reportSpotDetail = state.reportSpotDetail
-        reportSpotDetail?.id = state.trashSpotDetail.id
-        reportSpotDetail?.spotName = state.trashSpotDetail.name
-        reportSpotDetail?.latitude = state.trashSpotDetail.point.latitude
-        reportSpotDetail?.longitude = state.trashSpotDetail.point.longitude
-        reportSpotDetail?.trashType = state.trashSpotDetail.trashType.rawValue
+        var reportSpotDetail = TrashSpotFlattenDetailEntity(id: state.trashSpotDetail.id)
+        reportSpotDetail.spotName = state.trashSpotDetail.name
+        reportSpotDetail.latitude = state.trashSpotDetail.point.latitude
+        reportSpotDetail.longitude = state.trashSpotDetail.point.longitude
+        reportSpotDetail.trashType = state.trashSpotDetail.trashType.rawValue
         state.reportSpotDetail = reportSpotDetail
         return spotReportEffect(state, reportSpotUseCase)
         
@@ -347,9 +335,8 @@ private extension ReportFeature {
       
     case let .serverValidationCompleted(isValid, name):
       state.trashSpotDetail.name = name
-      if isValid {
-        return fetchTrashSpotDetailEffect(state.trashSpotDetail.id, fetchTrashSpotRawDetailUseCase)
-      } else {
+      if isValid { return .send(.combineSpotReportModel) }
+      else {
         return .run { send in
           await send(.setIsLoading(false))
           await send(.nextButtonIsEnabled(false))
@@ -389,24 +376,6 @@ private extension ReportFeature {
 
 /// MARK: - 순수하게 `ReportFeature`에서 사용할 `Effect들
 public extension ReportFeature {
-  
-  func fetchTrashSpotDetailEffect(
-    _ input: Int,
-    _ useCase: FetchTrashSpotRawDetailUseCase
-  ) -> Effect<Action> {
-    .run { send in
-      do {
-        await send(.setIsLoading(true))
-        let entity = try await useCase.execute(input)
-        await send(.fetchTrashSpotDetailEffect(.success(entity)))
-      } catch is CancellationError {
-        await send(.fetchTrashSpotDetailEffect(.failure(.taskCancelled)))
-      } catch {
-        await send(.fetchTrashSpotDetailEffect(.failure(.customError(message: error.localizedDescription))))
-      }
-    }
-  }
-  
   
   func spotReportEffect(
     _ state: Self.State,

--- a/Projects/Feature/SelectSpotLocation/SelectSpotLocationFeature/Sources/Views/SelectSpotLocationView.swift
+++ b/Projects/Feature/SelectSpotLocation/SelectSpotLocationFeature/Sources/Views/SelectSpotLocationView.swift
@@ -19,40 +19,55 @@ public struct SelectSpotLocationView: View {
   }
   
   public var body: some View {
-    VStack(alignment: .leading, spacing: .Number24) {
-      VStack(alignment: .leading, spacing: .Number8) {
-        Text("지도를 움직여,\n쓰레기통 위치를 지정해주세요")
-          .font(FontSet.Heading.heading1)
-          .foregroundStyle(ColorSet.Text.Primary)
-        Text(store.address)
-          .font(FontSet.Body.body3)
-          .foregroundStyle(ColorSet.Text.Secondary)
-          .multilineTextAlignment(.leading)
-      }
-      SelectSpotMapViewRepresentable(
-        userLocation: $store.userLocation
-      )
-      .onReceive {
-        store.send(.centerChanged($0))
-      }
-      .onMapMovingStarted {
-        store.send(.onMapMovingStarted)
-      }
-      .overlay(
-        Icon(
-          image: .normalTrashPin,
-          size: .Number56
+    VStack {
+      VStack(alignment: .leading, spacing: .Number24) {
+        VStack(alignment: .leading, spacing: .Number8) {
+          Text("지도를 움직여,\n쓰레기통 위치를 지정해주세요")
+            .font(FontSet.Heading.heading1)
+            .foregroundStyle(ColorSet.Text.Primary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+          Text(store.address)
+            .font(FontSet.Body.body3)
+            .foregroundStyle(ColorSet.Text.Secondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .lineLimit(1)
+        }
+        
+        Group {
+          SelectSpotMapViewRepresentable(
+            userLocation: $store.userLocation
+          )
+          .onReceive {
+            store.send(.centerChanged($0))
+          }
+          .onMapMovingStarted {
+            store.send(.onMapMovingStarted)
+          }
+          .overlay(
+            Icon(
+              image: .normalTrashPin,
+              size: .Number56
+            )
+            .offset(y: -16)
+            .allowsHitTesting(false),
+            alignment: .center
+          )
+        }
+        .aspectRatio(1, contentMode: .fit)
+        .clipCorners(.Number10, corners: .allCorners)
+        .overlay(
+          RoundedRectangle(cornerRadius: .Number10)
+            .stroke(ColorSet.Border.Secondary, lineWidth: .Number1)
         )
-        .offset(y: -16)
-        .allowsHitTesting(false),
-        alignment: .center
-      )
+        
+      }
+      .onAppear {
+        store.send(.onAppear)
+      }
+      .padding(.horizontal, .Number16)
+      .padding(.vertical, .Number24)
+      
+      Spacer()
     }
-    .onAppear {
-      store.send(.onAppear)
-    }
-    .padding(.horizontal, .Number16)
-    .padding(.vertical, .Number24)
-
   }
 }

--- a/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionChildFeature.swift
+++ b/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionChildFeature.swift
@@ -28,7 +28,11 @@ public struct SuggestionChildFeature {
     var selectKind: SelectSpotCategoryFeature.State = SelectSpotCategoryFeature.State()
     var selectPhoto: SelectSpotImageFeature.State = SelectSpotImageFeature.State()
     
-    public init() {}
+    public init(
+      _ initLocation: Coordinates? = nil
+    ) {
+      self.moveLocation = SelectSpotLocationFeature.State(initLocation)
+    }
   }
   
   public enum Action: Equatable {

--- a/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionFeature.swift
+++ b/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionFeature.swift
@@ -48,7 +48,11 @@ public struct SuggestionFeature {
     
     var selectedPhoto: UIImage? = nil
     
-    public init() {}
+    public init(
+      _ initLocation: Coordinates? = nil
+    ) {
+      self.child = SuggestionChildFeature.State(initLocation)
+    }
   }
   
   public enum Action: BindableAction, Equatable {


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #48 

## 🔎 작업 내용
1. 위치 정보 가져올 때, order 다양하게 가져와서 우선순위대로 불러오기 ✅
2. 신고하기 기능 → 전체 데이터 전부 보낼 필요 없음 ✅
3. 신고하기 response로 넘어오는 presignedURL이 옵셔널 ✅
4. 제보하기 & 신고하기 진입 시, 유저가 홈에서 이동해둔 지역 기준 ✅
## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Map view now tracks and exposes the last camera position, enabling contextual location data to be passed to suggestion and report features.
  * Enhanced reverse geocoding to provide more comprehensive address information.

* **Improvements**
  * Report and suggestion flows now initialize with the current map location, improving user experience when submitting or suggesting spots.
  * Address composition for reverse geocoding is more robust and detailed.

* **Bug Fixes**
  * Optional handling improved for spot name, trash type, presigned URLs, and location fields, reducing errors from missing or incomplete data.

* **Style**
  * Select spot location view layout and styling improved for better readability and appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->