### PR TITLE
Feature/#52 마이펫 바텀시트 실제 데이터 바인딩

### DIFF
--- a/Projects/Core/Cache/Sources/CacheActor.swift
+++ b/Projects/Core/Cache/Sources/CacheActor.swift
@@ -60,6 +60,16 @@ extension CacheActor {
       )
     }
   }
+  
+  public var MY_PET_SEASON_INFO_CACHE: TwoTierCache<MyPetCacheKey, MyPetSeasonInfoCacheModel> {
+    get async throws {
+      return try await cache(
+        .myPetSeasonInfo,
+        ttl: .high,
+        eviction: .none
+      )
+    }
+  }
 }
 
 /*

--- a/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
+++ b/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
@@ -31,6 +31,7 @@ public enum SampleCacheKey: CacheKey {
 
 public enum MyPetCacheKey: CacheKey {
   case myPetInfo
+  case myPetSeasonInfo
   
   public var directory: String { "MyPet" }
   public var fileName: String { "\(identifier).cache" }
@@ -38,6 +39,7 @@ public enum MyPetCacheKey: CacheKey {
   public var identifier: String {
     switch self {
     case .myPetInfo: "my_pet_info"
+    case .myPetSeasonInfo: "my_pet_season_info"
     }
   }
 }

--- a/Projects/Core/Cache/Sources/CacheModel/MyPetSeasonInfoCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/MyPetSeasonInfoCacheModel.swift
@@ -24,18 +24,21 @@ public struct PetGrowthCacheModel: Sendable, Equatable, Codable {
   public let levelType: String
   public let isLocked: Bool
   public let season: String
+  public let createdAt: String
   
   public init(
     nickname: String,
     needPoint: Int,
     levelType: String,
     isLocked: Bool,
-    season: String
+    season: String,
+    createdAt: String
   ) {
     self.nickname = nickname
     self.needPoint = needPoint
     self.levelType = levelType
     self.isLocked = isLocked
     self.season = season
+    self.createdAt = createdAt
   }
 }

--- a/Projects/Core/Cache/Sources/CacheModel/MyPetSeasonInfoCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/MyPetSeasonInfoCacheModel.swift
@@ -1,0 +1,41 @@
+//
+//  MyPetSeasonInfoCacheModel.swift
+//  Cache
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct MyPetSeasonInfoCacheModel: Sendable, Equatable, Codable {
+  public let seasonPetInfo: [PetGrowthCacheModel]
+  
+  public init(
+    _ seasonPetInfo: [PetGrowthCacheModel]
+  ) {
+    self.seasonPetInfo = seasonPetInfo
+  }
+}
+
+public struct PetGrowthCacheModel: Sendable, Equatable, Codable {
+  public let nickname: String
+  public let needPoint: Int
+  public let levelType: String
+  public let isLocked: Bool
+  public let season: String
+  
+  public init(
+    nickname: String,
+    needPoint: Int,
+    levelType: String,
+    isLocked: Bool,
+    season: String
+  ) {
+    self.nickname = nickname
+    self.needPoint = needPoint
+    self.levelType = levelType
+    self.isLocked = isLocked
+    self.season = season
+  }
+}

--- a/Projects/Core/Cache/Sources/Storage/DiskCacheStorage.swift
+++ b/Projects/Core/Cache/Sources/Storage/DiskCacheStorage.swift
@@ -86,15 +86,15 @@ extension DiskCacheStorage {
   /// - Parameters:
   ///   - key: 제거할 캐시의 key
   ///   - withDirectory: true인 경우 디렉토리 전체를 삭제
-  static func removeDiskCache(for key: Key, withDirectory: Bool = false) async throws {
-    try await Task.detached(priority: .background) {
+  static func removeDiskCache(for key: Key, withDirectory: Bool = false) {
+    Task.detached(priority: .background) {
       if withDirectory {
         try await removeAllInDirectory(for: key)
       } else {
         let fileURL = try cacheFileURL(for: key)
         try await removeFile(at: fileURL)
       }
-    }.value
+    }
   }
   
   /// 특정 디렉토리 내의 만료된 캐시들을 삭제합니다.

--- a/Projects/Core/Cache/Sources/Storage/DiskCacheStorage.swift
+++ b/Projects/Core/Cache/Sources/Storage/DiskCacheStorage.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import Utility
 
 /// `DiskCacheStorage`는 디스크에 캐시 데이터를 저장하고 관리
 /// 모든 작업은 백그라운드에서 수행되어 메인 스레드를 블로킹하지 않습니다.

--- a/Projects/Core/Cache/Sources/Storage/MemoryCacheStorage.swift
+++ b/Projects/Core/Cache/Sources/Storage/MemoryCacheStorage.swift
@@ -21,12 +21,12 @@ final class MemoryCacheStorage<Key: Hashable, Value: Codable & Sendable> {
     return entry.isExpired ? nil : entry
   }
   
-  func remove(forKey key: Key) throws {
+  func remove(forKey key: Key) {
     storage.removeValue(forKey: key)
   }
   
   // async 키워드도 제거 가능
-  func removeAll() throws {
+  func removeAll() {
     storage.removeAll()
   }
   

--- a/Projects/Core/Cache/Sources/TwoTierCache.swift
+++ b/Projects/Core/Cache/Sources/TwoTierCache.swift
@@ -76,7 +76,7 @@ public actor TwoTierCache<Key: CacheKey, Value: Codable & Sendable> {
       
       /// 초과분 제거 (메모리에서만)
       let toRemove = sortedEntries.prefix(entries.count - maxCount)
-      for (key, _) in toRemove { try memoryStorage.remove(forKey: key) }
+      for (key, _) in toRemove { memoryStorage.remove(forKey: key) }
       
     case let .fifo(maxCount):
       let allKeys = try memoryStorage.allKeys()
@@ -95,7 +95,7 @@ public actor TwoTierCache<Key: CacheKey, Value: Codable & Sendable> {
       
       /// 초과분 제거 (메모리에서만)
       let toRemove = sortedEntries.prefix(entries.count - maxCount)
-      for (key, _) in toRemove { try memoryStorage.remove(forKey: key) }
+      for (key, _) in toRemove { memoryStorage.remove(forKey: key) }
       
     case let .size(maxBytes): break
       /// TODO: 크기 기반 제거 정책 구현
@@ -163,19 +163,19 @@ public extension TwoTierCache {
   }
   
   /// Memory & Disk Cache에서 key에 해당하는 캐시 항목 제거
-  func remove(forKey key: Key) async {
+  func remove(forKey key: Key) {
     /// 1. Memory Cache에서 제거 (동기, 빠름)
-    try? memoryStorage.remove(forKey: key)
+    memoryStorage.remove(forKey: key)
     /// 2. Disk Cache에서 제거 (비동기, 백그라운드)
-    try? await DiskStorage.removeDiskCache(for: key)
+    DiskStorage.removeDiskCache(for: key)
   }
   
   /// Memory & Disk Cache 모두 초기화
-  func removeAll() async {
+  func removeAll() {
     /// 1. Memory Cache 초기화 (동기, 빠름)
-    try? memoryStorage.removeAll()
+    memoryStorage.removeAll()
     /// 2. Disk Cache 초기화 (비동기, 백그라운드)
-    try? await DiskStorage.removeDiskCache(for: cacheKey, withDirectory: true)
+    DiskStorage.removeDiskCache(for: cacheKey, withDirectory: true)
   }
   
   /// 만료된 캐시 항목 제거
@@ -225,7 +225,7 @@ public extension TwoTierCache {
   
   /// 메모리 캐시만 비우기 (디스크는 유지)
   func clearMemory() {
-    try? memoryStorage.removeAll()
+    memoryStorage.removeAll()
   }
   
   /// 캐시 항목 존재 여부 확인

--- a/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
@@ -56,7 +56,7 @@ public extension DesignKitImages {
   ///   - level: 레벨 (1-5)
   ///   - interaction: 상호작용 여부
   init(type: CatType, level: CatLevel, interaction: Bool) {
-    let imageName = "type:\(type.rawValue)_\(level.rawInt), interaction:\(interaction)"
+    let imageName = "type:\(type.rawString)_\(level.rawInt), interaction:\(interaction)"
     self.init(name: imageName)
   }
   
@@ -81,5 +81,5 @@ public struct CatImageSet {
     return DesignKitImages(name: name).swiftUIImage
   }
   
-  public static func imageURL(level: CatLevel, type: CatType, interaction: Bool = true) -> String { "type:\(type.rawValue)_\(level.rawInt), interaction:\(interaction)" }
+  public static func imageURL(level: CatLevel, type: CatType, interaction: Bool = true) -> String { "type:\(type.rawString)_\(level.rawInt), interaction:\(interaction)" }
 }

--- a/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
@@ -10,8 +10,13 @@ import SwiftUI
 
 // MARK: - Enum Types
 public enum CatType: String, Sendable, CaseIterable {
-  case basic = "basic"
-  /// 추후 다른 타입들 추가 가능
+  case _2025_07 = "2025_07"
+  
+  public var rawString: String {
+    switch self {
+    case ._2025_07: return "basic"
+    }
+  }
 }
 
 public enum CatLevel: String, Sendable, CaseIterable {

--- a/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Cat+.swift
@@ -6,7 +6,7 @@
 //  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
 
 // MARK: - Enum Types
 public enum CatType: String, Sendable, CaseIterable {
@@ -68,7 +68,13 @@ public extension DesignKitImages {
 
 // MARK: - 편의 메소드들
 public struct CatImageSet {
-  public static func imgae(level: CatLevel?, interaction: Bool, type: CatType) -> DesignKitImages {
+  public static func imgae(level: CatLevel?, interaction: Bool = true, type: CatType) -> DesignKitImages {
     return DesignKitImages(type: type, level: level ?? .level1, interaction: interaction)
   }
+  
+  public static func image(name: String) -> Image {
+    return DesignKitImages(name: name).swiftUIImage
+  }
+  
+  public static func imageURL(level: CatLevel, type: CatType, interaction: Bool = true) -> String { "type:\(type.rawValue)_\(level.rawInt), interaction:\(interaction)" }
 }

--- a/Projects/Data/Auth/AuthData/Sources/AuthRepositoryImpl.swift
+++ b/Projects/Data/Auth/AuthData/Sources/AuthRepositoryImpl.swift
@@ -10,6 +10,7 @@ import Foundation
 import AuthDomainInterface
 import AuthDataInterface
 import NetworkKit
+import Cache
 
 public extension AuthRepository {
   static func live(networker: NetworkKit) -> AuthRepository {
@@ -31,7 +32,15 @@ public extension AuthRepository {
       logout: {
         let endpoint = AuthEndpoint.logout()
         let _ = try await networker.execute(with: endpoint, timeout: 30)
+
         return ()
+      },
+      removeUserInfoCache: {
+        /// 유저 정보 관련 캐시를 제거
+        let mypetInfoCache = try await CacheActor.shared.MY_PET_INFO_CACHE
+        let myPetSeasonInfoCache = try await CacheActor.shared.MY_PET_SEASON_INFO_CACHE
+        await mypetInfoCache.removeAll()
+        await myPetSeasonInfoCache.removeAll()
       }
     )
   }

--- a/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
+++ b/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
@@ -11,30 +11,49 @@ import PetDomainInterface
 import PetDataInterface
 import NetworkKit
 import Cache
+import Utility
 
 public extension PetRepository {
   static func live(networker: NetworkKit) -> PetRepository {
     return .init(
       getPetInfo: {
-        let cacheKey = MyPetCacheKey.myPetInfo
-        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
-        if let hitData = await cache.value(forKey: cacheKey) {
-          let entity = PetInfoEntity(hitData)
-          return entity /// `cache-hit`인 경우, 캐시된 데이터를 반환
-        }
-        
         let endpoint = PetEndpoint.getPetInfo()
         let entity = try await networker.execute(with: endpoint).toEntity()
         
-        let cacheModel = MyPetInfoCacheModel(
-          nickname: entity.nickname,
-          point: entity.currentPoint,
-          levelType: entity.levelType.rawValue,
-          maxLevelStandard: entity.goalPoint
-        )
+        let cacheKey = MyPetCacheKey.myPetInfo
+        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
+        let cacheModel = entity.makeCacheModel()
+        await cache.remove(forKey: cacheKey)
         try await cache.insert(cacheModel, forKey: cacheKey)
-        /// `cache-miss`인 경우, 네트워크로부터 받은 데이터를 캐시에 저장하고 반환
         return entity
+      },
+      getPetInfoFromCache: {
+        let cacheKey = MyPetCacheKey.myPetInfo
+        let cache = try await CacheActor.shared.MY_PET_INFO_CACHE
+        guard let hitData = await cache.value(forKey: cacheKey) else {
+          throw CacheError.fileNotFound /// 이 때, api 호출 필요
+        }
+        return PetInfoEntity(hitData)
+       },
+      getPetSeasonInfo: {
+        let endpoint = PetEndpoint.getPetSeasonInfo()
+        let entity = try await networker.execute(with: endpoint).toEntity()
+        
+        let cacheKey = MyPetCacheKey.myPetSeasonInfo
+        let cache = try await CacheActor.shared.MY_PET_SEASON_INFO_CACHE
+        let cacheModel = entity.makeCacheModel()
+        
+        await cache.remove(forKey: cacheKey)
+        try await cache.insert(cacheModel, forKey: cacheKey)
+        return entity
+      },
+      getPetSeasonInfoFromCache: {
+        let cacheKey = MyPetCacheKey.myPetSeasonInfo
+        let cache = try await CacheActor.shared.MY_PET_SEASON_INFO_CACHE
+        guard let hitData = await cache.value(forKey: cacheKey) else {
+          throw CacheError.fileNotFound /// 이 때, api 호출 필요
+        }
+        return PetSeasonInfoEntity(hitData)
       }
     )
   }

--- a/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
@@ -35,7 +35,8 @@ public extension PetSeasonInfoDTO {
         needPoint: item.point,
         levelType: item.levelType,
         isLocked: item.isLocked,
-        season: item.season
+        season: item.season,
+        createdAt: item.createdAt
       )
     }
     return PetSeasonInfoEntity(growthEntity)

--- a/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
@@ -1,0 +1,43 @@
+//
+//  PetSeasonInfoDTO.swift
+//  PetDataInterface
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import PetDomainInterface
+import NetworkKit
+
+public struct PetSeasonInfoDTO: DTO {
+  public typealias Entity = PetSeasonInfoEntity
+  
+  public let userPetInfo: PetInfoDTO
+  public let list: [List]
+  
+  public struct List: Codable, Sendable {
+    public let userID: Int
+    public let nickname: String
+    public let point: Int
+    public let levelType: String
+    public let isLocked: Bool
+    public let season: String
+    public let createdAt: String
+  }
+}
+
+public extension PetSeasonInfoDTO {
+  func toEntity() -> Entity {
+    let growthEntity = list.map { item -> PetGrowthEntity in
+      return .init(
+        nickname: item.nickname,
+        needPoint: item.point,
+        levelType: item.levelType,
+        isLocked: item.isLocked,
+        season: item.season
+      )
+    }
+    return PetSeasonInfoEntity(growthEntity)
+  }
+}

--- a/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetSeasonInfoDTO.swift
@@ -17,7 +17,7 @@ public struct PetSeasonInfoDTO: DTO {
   public let list: [List]
   
   public struct List: Codable, Sendable {
-    public let userID: Int
+    public let userId: Int
     public let nickname: String
     public let point: Int
     public let levelType: String

--- a/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
@@ -21,4 +21,13 @@ public enum PetEndpoint: Sendable {
       parameters: .none
     )
   }
+  
+  public static func getPetSeasonInfo() -> Endpoint<PetSeasonInfoDTO> {
+    return Endpoint(
+      headers: .authorization(UserDefaultsKeys.accessToken),
+      method: .get,
+      path: "/pets/season",
+      parameters: .none
+    )
+  }
 }

--- a/Projects/Domain/Auth/AuthDomain/Sources/LogoutUseCaseImpl.swift
+++ b/Projects/Domain/Auth/AuthDomain/Sources/LogoutUseCaseImpl.swift
@@ -13,6 +13,7 @@ extension LogoutUseCase {
   public static func live(repository: AuthRepository) -> LogoutUseCase {
     .init {
       try await repository.logout()
+      try await repository.removeUserInfoCache()
     }
   }
 }

--- a/Projects/Domain/Auth/AuthDomainInterface/Sources/AuthRepository.swift
+++ b/Projects/Domain/Auth/AuthDomainInterface/Sources/AuthRepository.swift
@@ -12,16 +12,18 @@ public struct AuthRepository {
   public var requestAppleLogin: @Sendable (_ token: String) async throws -> SocialLoginEntity
   public var requestSignUp: @Sendable (SignUpInput) async throws -> Void
   public var logout: @Sendable () async throws -> Void
+  public var removeUserInfoCache: @Sendable () async throws -> Void
   
 
   public init(
     requestAppleLogin: @Sendable @escaping (_ token: String) async throws -> SocialLoginEntity,
     requestSignUp: @Sendable @escaping (SignUpInput) async throws -> Void,
-    logout: @Sendable @escaping () async throws -> Void
+    logout: @Sendable @escaping () async throws -> Void,
+    removeUserInfoCache: @Sendable @escaping () async throws -> Void
   ) {
     self.requestAppleLogin = requestAppleLogin
     self.requestSignUp = requestSignUp
     self.logout = logout
-    
+    self.removeUserInfoCache = removeUserInfoCache
   }
 }

--- a/Projects/Domain/Pet/PetDomain/Sources/CheckPetInfoUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/CheckPetInfoUseCaseImpl.swift
@@ -7,13 +7,23 @@
 //
 
 import Foundation
+import Utility
 import PetDomainInterface
 
 extension CheckPetInfoUseCase {
   public static func live(repository: PetRepository) -> CheckPetInfoUseCase {
     .init {
-      let entity = try await repository.getPetInfo()
-      return entity
+      do {
+        let entity = try await repository.getPetInfoFromCache()
+        return entity
+      } catch let error as CacheError {
+        switch error {
+        case .fileNotFound:
+          let newEntity = try await repository.getPetInfo()
+          return newEntity
+        default : throw error
+        }
+      }
     }
   }
 }

--- a/Projects/Domain/Pet/PetDomain/Sources/FetchPetSeasonInfoUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/FetchPetSeasonInfoUseCaseImpl.swift
@@ -1,0 +1,29 @@
+//
+//  FetchPetSeasonInfoUseCaseImpl.swift
+//  PetDomain
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Utility
+import PetDomainInterface
+
+extension FetchPetSeasonInfoUseCase {
+  public static func live(repository: PetRepository) -> FetchPetSeasonInfoUseCase {
+    .init {
+      do {
+        let entity = try await repository.getPetSeasonInfoFromCache()
+        return entity
+      } catch let error as CacheError {
+        switch error {
+        case .fileNotFound:
+          let newEntity = try await repository.getPetSeasonInfo()
+          return newEntity
+        default : throw error
+        }
+      }
+    }
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/FetchPetSeasonInfoUseCaseKey.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/FetchPetSeasonInfoUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  FetchPetSeasonInfoUseCaseKey.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum FetchPetSeasonInfoUseCaseKey: DependencyKey {
+  public static var liveValue: FetchPetSeasonInfoUseCase { FetchPetSeasonInfoUseCaseProvider() }
+  public static var previewValue: FetchPetSeasonInfoUseCase { FetchPetSeasonInfoUseCaseProvider() }
+  public static var testValue: FetchPetSeasonInfoUseCase { FetchPetSeasonInfoUseCaseProvider() }
+}
+
+private var FetchPetSeasonInfoUseCaseProvider: () -> FetchPetSeasonInfoUseCase = {
+  fatalError("PetUseCase Dependency not configured")
+}
+
+public func FetchPetSeasonInfoUseCaseRegister(
+  provider: @escaping () -> FetchPetSeasonInfoUseCase
+) {
+  FetchPetSeasonInfoUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var FetchPetSeasonInfoUseCase: FetchPetSeasonInfoUseCase {
+    get { self[FetchPetSeasonInfoUseCaseKey.self] }
+    set { self[FetchPetSeasonInfoUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetInfoEntity.swift
@@ -41,4 +41,13 @@ public struct PetInfoEntity: Sendable, Equatable {
       maxLevelStandard: cacheModel.goalPoint
     )
   }
+  
+  public func makeCacheModel() -> MyPetInfoCacheModel {
+    return MyPetInfoCacheModel(
+      nickname: self.nickname,
+      point: self.currentPoint,
+      levelType: self.levelType.rawValue,
+      maxLevelStandard: self.goalPoint
+    )
+  }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
@@ -37,19 +37,22 @@ public struct PetGrowthEntity: Sendable, Equatable {
   public let levelType: CatLevel /// 해당 레벨의 타입
   public let isLocked: Bool /// 해당 레벨이 잠겨있는지 여부
   public let season: CatType /// 현재 시즌 이름 (ex. `basic`)
+  public let createdAt: String
   
   public init(
     nickname: String,
     needPoint: Int,
     levelType: String,
     isLocked: Bool,
-    season: String
+    season: String,
+    createdAt: String
   ) {
     self.nickname = nickname
     self.needPoint = needPoint
     self.levelType = CatLevel(rawValue: levelType) ?? .level1
     self.isLocked = isLocked
     self.season = CatType(rawValue: season) ?? ._2025_07
+    self.createdAt = createdAt
   }
   
   public init(
@@ -60,7 +63,8 @@ public struct PetGrowthEntity: Sendable, Equatable {
       needPoint: cacheModel.needPoint,
       levelType: cacheModel.levelType,
       isLocked: cacheModel.isLocked,
-      season: cacheModel.season
+      season: cacheModel.season,
+      createdAt: cacheModel.createdAt
     )
   }
   
@@ -70,7 +74,8 @@ public struct PetGrowthEntity: Sendable, Equatable {
       needPoint: data.needPoint,
       levelType: data.levelType.rawValue,
       isLocked: data.isLocked,
-      season: data.season.rawValue
+      season: data.season.rawValue,
+      createdAt: data.createdAt
     )
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
@@ -1,0 +1,76 @@
+//
+//  PetSeasonInfoEntity.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import DesignKit
+import Cache
+
+public struct PetSeasonInfoEntity: Sendable, Equatable {
+  public let seasonPetInfo: [PetGrowthEntity]
+  
+  public init(
+    _ seasonPetInfo: [PetGrowthEntity]
+  ) {
+    self.seasonPetInfo = seasonPetInfo
+  }
+  
+  public init(
+    _ cacheModel: MyPetSeasonInfoCacheModel
+  ) {
+    self.seasonPetInfo = cacheModel.seasonPetInfo.map { PetGrowthEntity($0) }
+  }
+  
+  public func makeCacheModel() -> MyPetSeasonInfoCacheModel {
+    return MyPetSeasonInfoCacheModel(seasonPetInfo.map { $0.makeCacheModel($0) }
+    )
+  }
+}
+
+public struct PetGrowthEntity: Sendable, Equatable {
+  public let nickname: String /// 해당 시즌의 고양이 이름 (관형사 포함)
+  public let needPoint: Int /// 해당 레벨에 도달하기 위해 필요한 포인트
+  public let levelType: CatLevel /// 해당 레벨의 타입
+  public let isLocked: Bool /// 해당 레벨이 잠겨있는지 여부
+  public let season: CatType /// 현재 시즌 이름 (ex. `basic`)
+  
+  public init(
+    nickname: String,
+    needPoint: Int,
+    levelType: String,
+    isLocked: Bool,
+    season: String
+  ) {
+    self.nickname = nickname
+    self.needPoint = needPoint
+    self.levelType = CatLevel(rawValue: levelType) ?? .level1
+    self.isLocked = isLocked
+    self.season = CatType(rawValue: season) ?? ._2025_07
+  }
+  
+  public init(
+    _ cacheModel: PetGrowthCacheModel
+  ) {
+    self.init(
+      nickname: cacheModel.nickname,
+      needPoint: cacheModel.needPoint,
+      levelType: cacheModel.levelType,
+      isLocked: cacheModel.isLocked,
+      season: cacheModel.season
+    )
+  }
+  
+  fileprivate func makeCacheModel(_ data: Self) -> PetGrowthCacheModel {
+    return PetGrowthCacheModel(
+      nickname: data.nickname,
+      needPoint: data.needPoint,
+      levelType: data.levelType.rawValue,
+      isLocked: data.isLocked,
+      season: data.season.rawValue
+    )
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
@@ -7,14 +7,24 @@
 //
 
 import Foundation
+import Cache
 
 public struct PetRepository {
   
   public var getPetInfo: @Sendable () async throws -> PetInfoEntity
+  public var getPetInfoFromCache: @Sendable () async throws -> PetInfoEntity
+  public var getPetSeasonInfo: @Sendable () async throws -> PetSeasonInfoEntity
+  public var getPetSeasonInfoFromCache: @Sendable () async throws -> PetSeasonInfoEntity
 
   public init(
-    getPetInfo: @Sendable @escaping () async throws -> PetInfoEntity
+    getPetInfo: @Sendable @escaping () async throws -> PetInfoEntity,
+    getPetInfoFromCache: @Sendable @escaping () async throws -> PetInfoEntity,
+    getPetSeasonInfo: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
+    getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity
   ) {
     self.getPetInfo = getPetInfo
+    self.getPetInfoFromCache = getPetInfoFromCache
+    self.getPetSeasonInfo = getPetSeasonInfo
+    self.getPetSeasonInfoFromCache = getPetSeasonInfoFromCache
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/FetchPetSeasonInfoUseCase.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/FetchPetSeasonInfoUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  FetchPetSeasonInfoUseCase.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct FetchPetSeasonInfoUseCase {
+  public var execute: @Sendable () async throws -> PetSeasonInfoEntity
+  
+  public init(execute: @Sendable @escaping () async throws -> PetSeasonInfoEntity) {
+    self.execute = execute
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -23,6 +23,8 @@ public struct MyPetFeature {
   @ObservableState
   public struct State {
     public var path = StackState<Path.State>()
+    public var petGrowthList: MyPetGrowthListFeature.State
+    
     public var myPetInfo: PetInfoEntity?
     
     /// 마이 펫 이미지 관련
@@ -37,35 +39,24 @@ public struct MyPetFeature {
     
     public var isLoggedIn: Bool = false
     
-    public var catCards = [
-      CatCard(image: "cat1", isLocked: false),
-      CatCard(image: "cat2", isLocked: false),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true),
-      CatCard(image: nil, isLocked: true)
-    ]
+    public var catCards: [CatCard] = []
+    public var growthRecords: [GrowthRecord] = []
     
-    public var growthRecords = [
-      GrowthRecord(level: "Lv.1", title: "작고 소중한 {{고양이 이름}}", description: "", date: "YY.MM.DD.", stampCount: "0쓰담", isLocked: false),
-      GrowthRecord(level: "Lv.2", title: "호기심 가득한 {{고양이 이...", description: "", date: "YY.MM.DD.", stampCount: "20쓰담", isLocked: false),
-      GrowthRecord(level: "Lv.3", title: "쑥쑥 자라나는 {{고양이...", description: "", date: nil, stampCount: "110쓰담", isLocked: true),
-      GrowthRecord(level: "Lv.4", title: "왕 커서 귀여운{{고양이 이...", description: "", date: nil, stampCount: "N쓰담", isLocked: true),
-      GrowthRecord(level: "Special", title: "{{스페셜 문구}} {{고양이...", description: "", date: nil, stampCount: "N쓰담", isLocked: true)
-    ]
-    
-    
-    public init() {}
+    public init() {
+      self.petGrowthList = MyPetGrowthListFeature.State()
+    }
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case path(StackActionOf<Path>)
+    case petGrowthList(MyPetGrowthListFeature.Action)
     case onAppear
     case checkLoggedIn
     case fetchMyPetInfo
     
     case fetchMyPetInfoResult(Result<PetInfoEntity, NetworkError>)
+    case fetchMyPetLayout
     
     case petNicknameButtonTapped
     case petDetailButtonTapped
@@ -95,9 +86,11 @@ public struct MyPetFeature {
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
+    Scope(state: \.petGrowthList, action: \.petGrowthList) {
+      MyPetGrowthListFeature()
+    }
     Reduce { state, action in
       switch action {
-        
       case .onAppear:
         return .send(.checkLoggedIn)
         
@@ -113,7 +106,9 @@ public struct MyPetFeature {
         switch result {
         case let .success(entity):
           state.myPetInfo = entity
-          return .none
+          /// TODO: - `GrowthListFeature`에 데이터 기반 레이아웃 호출
+          return .send(.petGrowthList(.fetchGrowthList(entity)))
+          
         case let .failure(error):
           state.myPetInfo = nil
           print("Error fetching pet info: \(error)")

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -106,8 +106,7 @@ public struct MyPetFeature {
         switch result {
         case let .success(entity):
           state.myPetInfo = entity
-          /// TODO: - `GrowthListFeature`에 데이터 기반 레이아웃 호출
-          return .send(.petGrowthList(.fetchGrowthList(entity)))
+          return .send(.petGrowthList(.fetchPetSeasonInfo))
           
         case let .failure(error):
           state.myPetInfo = nil

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
@@ -1,0 +1,68 @@
+//
+//  MyPetGrowthListFeature.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignKit
+
+import PetDomainInterface
+
+@Reducer
+public struct MyPetGrowthListFeature {
+  
+  public init() {}
+  
+  @ObservableState
+  public struct State: Equatable {
+    public var catCards: [CatCard] = []
+    public var growthRecords: [GrowthRecord] = []
+    
+    public init() {}
+  }
+  
+  public enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case fetchGrowthList(PetInfoEntity)
+    
+    case fetchCatCards([CatCard])
+  }
+  
+  public var body: some ReducerOf<Self> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case let .fetchGrowthList(petInfo):
+        /// TODO: - `CatType`도 외부에서 주입 가능하도록 변경해야함....!
+        return fetchGrowthList(with: petInfo, season: .basic)
+        
+      case let .fetchCatCards(cards):
+        state.catCards = cards
+        return .none
+        
+      default: return .none
+      }
+    }
+  }
+}
+
+extension MyPetGrowthListFeature {
+  fileprivate func fetchGrowthList(
+    with petInfo: PetInfoEntity,
+    season: CatType
+  ) -> Effect<Action> {
+    let trasnformed = CatLevel.allCases.map { catLevel -> CatCard in
+      let catImage = CatImageSet.imageURL(level: catLevel, type: season)
+      return .init(
+        isLocked: petInfo.levelType.rawInt < catLevel.rawInt,
+        imageURL: catImage
+      )
+    }
+    return .send(.fetchCatCards(trasnformed))
+  }
+}
+  

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
@@ -84,11 +84,21 @@ extension MyPetGrowthListFeature {
     return .fetchCatCards(catCards)
   }
   
-  // 실제 구현 시 사용할 함수
   fileprivate func fetchGrowthRecordsAction(with seasonData: PetSeasonInfoEntity) -> Action {
-    // 실제 구현 로직
-    let growthRecords: [GrowthRecord] = [] // 실제 데이터 처리
+    let catCards = seasonData.seasonPetInfo.map { item -> CatCard in
+      let imageURL = CatImageSet.imageURL(level: item.levelType, type: item.season)
+      return .init(isLocked: item.isLocked, imageURL: imageURL)
+    }
+    
+    let growthRecords = seasonData.seasonPetInfo.enumerated().map { index, item -> GrowthRecord in
+      return .init(
+        catCard: catCards[index],
+        levelType: item.levelType,
+        goalStamp: item.needPoint,
+        nickname: item.nickname,
+        createdAt: item.createdAt
+      )
+    }
     return .fetchGrowthRecords(growthRecords)
   }
 }
-

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import ComposableArchitecture
 import DesignKit
+import Utility
 
 import PetDomainInterface
 
@@ -27,21 +28,29 @@ public struct MyPetGrowthListFeature {
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
-    case fetchGrowthList(PetInfoEntity)
+    case fetchPetSeasonInfo
+    case fetchPetSeasonInfoResult(Result<PetSeasonInfoEntity, NetworkError>)
     
     case fetchCatCards([CatCard])
+    case fetchGrowthRecords([GrowthRecord])
   }
+  
+  @Dependency(\.FetchPetSeasonInfoUseCase) var fetchPetSeasonInfoUseCase
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
     Reduce { state, action in
       switch action {
-      case let .fetchGrowthList(petInfo):
-        /// TODO: - `CatType`도 외부에서 주입 가능하도록 변경해야함....!
-        return fetchGrowthList(with: petInfo, season: .basic)
         
-      case let .fetchCatCards(cards):
-        state.catCards = cards
+      case .fetchPetSeasonInfo:
+        return fetchGrowthList()
+        
+      case let .fetchCatCards(catCards):
+        state.catCards = catCards
+        return .none
+        
+      case let .fetchGrowthRecords(growthRecords):
+        state.growthRecords = growthRecords
         return .none
         
       default: return .none
@@ -51,18 +60,35 @@ public struct MyPetGrowthListFeature {
 }
 
 extension MyPetGrowthListFeature {
-  fileprivate func fetchGrowthList(
-    with petInfo: PetInfoEntity,
-    season: CatType
-  ) -> Effect<Action> {
-    let trasnformed = CatLevel.allCases.map { catLevel -> CatCard in
-      let catImage = CatImageSet.imageURL(level: catLevel, type: season)
-      return .init(
-        isLocked: petInfo.levelType.rawInt < catLevel.rawInt,
-        imageURL: catImage
-      )
+  fileprivate func fetchGrowthList() -> Effect<Action> {
+    return .run { send in
+      do {
+        let entity = try await fetchPetSeasonInfoUseCase.execute()
+        
+        // MARK: - 여기 병합 시켜야함....
+        await send(fetchCatCardsAction(with: entity))
+        await send(fetchGrowthRecordsAction(with: entity))
+      } catch is CancellationError {
+        await send(.fetchPetSeasonInfoResult(.failure(.taskCancelled)))
+      } catch {
+        await send(.fetchPetSeasonInfoResult(.failure(.customError(message: error.localizedDescription))))
+      }
     }
-    return .send(.fetchCatCards(trasnformed))
+  }
+  
+  fileprivate func fetchCatCardsAction(with seasonData: PetSeasonInfoEntity) -> Action {
+    let catCards = seasonData.seasonPetInfo.map { item -> CatCard in
+      let imageURL = CatImageSet.imageURL(level: item.levelType, type: item.season)
+      return .init(isLocked: item.isLocked, imageURL: imageURL)
+    }
+    return .fetchCatCards(catCards)
+  }
+  
+  // 실제 구현 시 사용할 함수
+  fileprivate func fetchGrowthRecordsAction(with seasonData: PetSeasonInfoEntity) -> Action {
+    // 실제 구현 로직
+    let growthRecords: [GrowthRecord] = [] // 실제 데이터 처리
+    return .fetchGrowthRecords(growthRecords)
   }
 }
-  
+

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -31,6 +31,10 @@ public struct CatCardCell: View {
               renderingMode: .template,
               color: ColorSet.Icon.Tertiary
             )
+          } else {
+            CatImageSet.image(name: card.imageURL)
+              .resizable()
+              .scaledToFit()
           }
         }
       )

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -23,17 +23,21 @@ public struct GrowthRecordCell: View {
       HStack(alignment: .center, spacing: .Number12) {
         // 썸네일 이미지
         RoundedRectangle(cornerRadius: .Number8)
-          .fill(record.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
+          .fill(record.catCard.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
           .frame(width: .Number64, height: .Number64)
           .overlay(
             Group {
-              if record.isLocked {
+              if record.catCard.isLocked {
                 Icon(
                   image: .lock,
                   size: .Number24,
                   renderingMode: .template,
                   color: ColorSet.Icon.Tertiary
                 )
+              } else {
+                CatImageSet.image(name: record.catCard.imageURL)
+                  .resizable()
+                  .scaledToFit()
               }
             }
           )
@@ -41,15 +45,18 @@ public struct GrowthRecordCell: View {
         // 정보 영역
         VStack(alignment: .leading, spacing: .Number4) {
           HStack(alignment: .center, spacing: .Number6) {
-            Badge(text: .constant(record.level), state: .primary)
+            Badge(
+              text: .constant("Lv.\(record.levelType.rawInt)"),
+              state: .primary
+            )
             
-            Text(record.title)
+            Text(record.nickname)
               .font(FontSet.Body.body2)
               .foregroundColor(ColorSet.Text.Primary)
               .lineLimit(1)
           }
           
-          if let date = record.date {
+          if let date = record.didAchieveDate {
             Text(date)
               .font(FontSet.Caption.caption1)
               .foregroundColor(ColorSet.Text.Tertiary)
@@ -61,12 +68,12 @@ public struct GrowthRecordCell: View {
       }
       
       // 쓰담 수
-      Text(record.stampCount)
+      Text("\(record.goalStamp)쓰담")
         .font(FontSet.Caption.caption1)
         .foregroundColor(ColorSet.Text.Tertiary)
     }
     .padding(.horizontal, .Number16)
     .padding(.vertical, .Number8)
-    .opacity(record.isLocked ? 0.4 : 1.0)
+    .opacity(record.catCard.isLocked ? 0.4 : 1.0)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatCard.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatCard.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public struct CatCard: Identifiable {
+public struct CatCard: Identifiable, Equatable {
   public let id = UUID()
-  public let image: String? // nil이면 잠긴 상태
   public let isLocked: Bool
+  public let imageURL: String
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
@@ -6,14 +6,29 @@
 //  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
 //
 
-import Foundation
+import SwiftUI
+import Utility
+import DesignKit
 
 public struct GrowthRecord: Identifiable, Equatable {
   public let id = UUID()
-  public let level: String
-  public let title: String
-  public let description: String
-  public let date: String?
-  public let stampCount: String
-  public let isLocked: Bool
+  public let catCard: CatCard /// 고양이 카드 정보
+  public let levelType: CatLevel /// 고양이 레벨 타입
+  public let goalStamp: Int /// 레벨업을 위한 쓰담
+  public let nickname: String
+  public var didAchieveDate: String? = nil /// 레벨업 달성 날짜 (yy-MM-dd 형식)
+  
+  public init(
+    catCard: CatCard,
+    levelType: CatLevel,
+    goalStamp: Int,
+    nickname: String,
+    createdAt: String
+  ) {
+    self.catCard = catCard
+    self.levelType = levelType
+    self.goalStamp = goalStamp
+    self.nickname = nickname
+    self.didAchieveDate = createdAt.toFormattedDateOptional()
+  }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/GrowthRecord.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct GrowthRecord: Identifiable {
+public struct GrowthRecord: Identifiable, Equatable {
   public let id = UUID()
   public let level: String
   public let title: String

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
@@ -21,7 +21,7 @@ public struct MyPetCardView: View {
   
   public var action: @Sendable () -> Void
   
-  @State private var progress: CGFloat = 0.0
+  private var progress: CGFloat { goalStamp > 0 ? CGFloat(currentStamps) / CGFloat(goalStamp) : 0.0 }
   
   public init(
     myPetInfo: PetInfoEntity?,
@@ -101,11 +101,5 @@ public struct MyPetCardView: View {
     .background(ColorSet.Background.Primary)
     .cornerRadius(.Number16)
     .elevation(level: .medium, cornerRadius: .Number16)
-    .onChange(of: myPetInfo) { _, _ in
-      withAnimation(.easeInOut(duration: 1.0)) {
-        print("Current Stamps: \(currentStamps), Goal Stamp: \(goalStamp) || Progress: \(progress)")
-        progress = goalStamp > 0 ? CGFloat(currentStamps) / CGFloat(goalStamp) : 0.0
-      }
-    }
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
@@ -7,27 +7,23 @@
 //
 
 import SwiftUI
+import ComposableArchitecture
 import DesignKit
 
 public struct BigBottomSheetContentView: View {
-  // 샘플 데이터
-  
-  private let catCards: [CatCard]
-  private let growthRecords: [GrowthRecord]
+  @Bindable var store: StoreOf<MyPetGrowthListFeature>
   
   @Binding private var startBottomSheetInsideScroll: Bool
   @Binding private var bottomSheetDragEnabled: Bool
   
   public init(
-    catCards: [CatCard],
-    growthRecords: [GrowthRecord],
+    store: StoreOf<MyPetGrowthListFeature>,
     startBottomSheetInsideScroll: Binding<Bool>,
     bottomSheetDragEnabled: Binding<Bool>
   ) {
-    self.catCards = catCards
-    self.growthRecords = growthRecords
     self._startBottomSheetInsideScroll = startBottomSheetInsideScroll
     self._bottomSheetDragEnabled = bottomSheetDragEnabled
+    self.store = store
   }
   
   public var body: some View {
@@ -35,7 +31,7 @@ public struct BigBottomSheetContentView: View {
       // 고양이 카드 가로 스크롤
       ScrollView(.horizontal, showsIndicators: false) {
         HStack(spacing: .Number12) {
-          ForEach(catCards) { CatCardCell(card: $0) }
+          ForEach(store.catCards) { CatCardCell(card: $0) }
         }
         .padding(.horizontal, .Number16)
         .padding(.vertical, .Number12)
@@ -72,7 +68,7 @@ public struct BigBottomSheetContentView: View {
       // 성장 기록 리스트 (스크롤 가능)
       ScrollView(.vertical, showsIndicators: false) {
         VStack {
-          ForEach(growthRecords) { GrowthRecordCell(record: $0) }
+//          ForEach(growthRecords) { GrowthRecordCell(record: $0) }
         }
       }
     }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
@@ -68,7 +68,7 @@ public struct BigBottomSheetContentView: View {
       // 성장 기록 리스트 (스크롤 가능)
       ScrollView(.vertical, showsIndicators: false) {
         VStack {
-//          ForEach(growthRecords) { GrowthRecordCell(record: $0) }
+          ForEach(store.growthRecords) { GrowthRecordCell(record: $0) }
         }
       }
     }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -159,8 +159,7 @@ public struct MyPetView: View {
     VStack {
       CommonHeaderView
       BigBottomSheetContentView(
-        catCards: store.catCards,
-        growthRecords: store.growthRecords,
+        store: store.scope(state: \.petGrowthList, action: \.petGrowthList),
         startBottomSheetInsideScroll: $startBottomSheetInsideScroll,
         bottomSheetDragEnabled: $bottomSheetDragEnabled
       )

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -109,7 +109,7 @@ public struct MyPetView: View {
               asset: CatImageSet.imgae(
                 level: store.myPetInfo?.levelType,
                 interaction: store.isMyPetInteracted,
-                type: .basic
+                type: ._2025_07
               )
             )
             .resizable()

--- a/Projects/Shared/Utility/Sources/Errors/CacheError.swift
+++ b/Projects/Shared/Utility/Sources/Errors/CacheError.swift
@@ -1,9 +1,9 @@
 //
 //  CacheError.swift
-//  Cache
+//  Utility
 //
-//  Created by 조용인 on 3/21/25.
-//  Copyright © 2025 com.yongin.pida. All rights reserved.
+//  Created by 조용인 on 7/18/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
 //
 
 import Foundation
@@ -11,6 +11,7 @@ import Foundation
 /// Cache 모듈에서 발생할 수 있는 에러를 정의
 public enum CacheError: Error, LocalizedError {
   case directoryCreationFailed
+  case fileNotFound
   case encodingFailed
   case decodingFailed
   case invalidKey
@@ -19,6 +20,7 @@ public enum CacheError: Error, LocalizedError {
   public var errorDescription: String? {
     switch self {
     case .directoryCreationFailed: return "캐시 디렉토리를 생성하는데 실패했습니다."
+    case .fileNotFound: return "캐시 파일을 찾을 수 없습니다."
     case .encodingFailed: return "캐시 항목을 인코딩하는데 실패했습니다."
     case .decodingFailed: return "캐시 항목을 디코딩하는데 실패했습니다."
     case .invalidKey: return "유효하지 않은 캐시 키입니다."

--- a/Projects/Shared/Utility/Sources/Extension/String+.swift
+++ b/Projects/Shared/Utility/Sources/Extension/String+.swift
@@ -18,4 +18,27 @@ extension String {
     let isBasicValid = self.range(of: regex, options: .regularExpression) != nil
     return isBasicValid && !containsEmoji
   }
+  
+  /// ISO 8601 날짜 문자열을 YY-MM-DD 형식으로 변환
+  /// - Returns: 변환된 날짜 문자열 또는 변환 실패 시 원본 문자열
+  public func toFormattedDate(_ format: String = "yy-MM-dd") -> String {
+    let inputFormatter = DateFormatter()
+    inputFormatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    inputFormatter.locale = Locale(identifier: "en_US_POSIX")
+    inputFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+    
+    let outputFormatter = DateFormatter()
+    outputFormatter.dateFormat = format
+    
+    guard let date = inputFormatter.date(from: self) else {
+      // 변환 실패 시 원본 문자열 반환
+      return self
+    }
+    
+    return outputFormatter.string(from: date)
+  }
+  
+  public func toFormattedDateOptional(_ format: String = "yy-MM-dd") -> String? {
+    return self.toFormattedDate(format) == self ? nil : self.toFormattedDate(format)
+  }
 }

--- a/Projects/Sseudam/Sources/DependencyRegister.swift
+++ b/Projects/Sseudam/Sources/DependencyRegister.swift
@@ -151,5 +151,9 @@ struct DependencyRegister {
     CheckPetInfoUseCaseRegister {
       CheckPetInfoUseCase.live(repository: petRepository)
     }
+    
+    FetchPetSeasonInfoUseCaseRegister {
+      FetchPetSeasonInfoUseCase.live(repository: petRepository)
+    }
   }
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #52 

## 🔎 작업 내용
- 마이펫 페이지의 바텀시트 데이터 바인딩 완료
- 로그아웃 시, 마이펫 관련 cache 제거
- 마이펫 페이지에서 직접 로그인을 진행할 경우, 로그인 후 펫 카드뷰의 progress가 반영되지 않는 이슈 수정
## 📷 스크린샷

https://github.com/user-attachments/assets/ae6119f9-6818-4c48-9fdc-6fd376b9a4c3


## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced pet season growth tracking, displaying a list of pet growth records and cat cards in the MyPet section.
  * Added support for fetching and caching seasonal pet information, with fallback to network retrieval if cache is empty.
  * New UI components for visualizing pet growth history and achievements.
  * Added date formatting utilities for consistent display of achievement dates.
  * Cat image assets and types updated for enhanced visuals.

* **Improvements**
  * Logout now also clears cached user and pet information for improved data privacy.
  * Enhanced error handling and messaging when cached data is missing.
  * Refined data structures for growth records and cat cards, improving display and maintainability.

* **Bug Fixes**
  * Adjusted image and label rendering logic in growth record and cat card views for accuracy and clarity.

* **Chores**
  * Updated dependency injection to support new use cases and caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->