### PR TITLE
Feature/#60 마이펫 디테일 페이지 구현

### DIFF
--- a/Projects/Core/Cache/Sources/CacheActor.swift
+++ b/Projects/Core/Cache/Sources/CacheActor.swift
@@ -70,6 +70,16 @@ extension CacheActor {
       )
     }
   }
+  
+  public var MY_PET_HISTORY_INFO_CACHE: TwoTierCache<MyPetCacheKey, MyPetHistoryInfoCacheModel> {
+    get async throws {
+      return try await cache(
+        .myPetHistoryInfo,
+        ttl: .high,
+        eviction: .none
+      )
+    }
+  }
 }
 
 /*

--- a/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
+++ b/Projects/Core/Cache/Sources/CacheComponent/CacheKey.swift
@@ -32,6 +32,7 @@ public enum SampleCacheKey: CacheKey {
 public enum MyPetCacheKey: CacheKey {
   case myPetInfo
   case myPetSeasonInfo
+  case myPetHistoryInfo
   
   public var directory: String { "MyPet" }
   public var fileName: String { "\(identifier).cache" }
@@ -40,6 +41,7 @@ public enum MyPetCacheKey: CacheKey {
     switch self {
     case .myPetInfo: "my_pet_info"
     case .myPetSeasonInfo: "my_pet_season_info"
+    case .myPetHistoryInfo: "my_pet_history_info"
     }
   }
 }

--- a/Projects/Core/Cache/Sources/CacheModel/MyPetHistoryInfoCacheModel.swift
+++ b/Projects/Core/Cache/Sources/CacheModel/MyPetHistoryInfoCacheModel.swift
@@ -1,0 +1,38 @@
+//
+//  MyPetHistoryInfoCacheModel.swift
+//  
+//
+//  Created by 조용인 on 7/26/25.
+//
+
+import Foundation
+
+public struct MyPetHistoryInfoCacheModel: Sendable, Equatable, Codable {
+  public let historyInfo: [PetHistoryEachCacheModel]
+  
+  public init(
+    _ historyInfo: [PetHistoryEachCacheModel]
+  ) {
+    self.historyInfo = historyInfo
+  }
+}
+
+public struct PetHistoryEachCacheModel: Sendable, Equatable, Codable {
+  public let nickname: String
+  public let point: Int
+  public let levelType: String
+  public let season: String
+  
+  public init(
+    nickname: String,
+    point: Int,
+    levelType: String,
+    season: String
+  ) {
+    self.nickname = nickname
+    self.point = point
+    self.levelType = levelType
+    self.season = season
+    
+  }
+}

--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/006F9D.colorset/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/006F9D.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0x9D",
+          "green" : "0x6F",
+          "red" : "0x00"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/9FD5FB.colorset/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/9FD5FB.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFB",
+          "green" : "0xD5",
+          "red" : "0x9F"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/E0F2FF.colorset/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/E0F2FF.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xF2",
+          "red" : "0xE0"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Sources/Resource+/Color+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Color+.swift
@@ -110,6 +110,12 @@ extension DesignKitAsset {
       public static let Kakao = DesignKitAsset.Colors.kakao.swiftUIColor
       public static let Apple = ColorSet.Gray._1000
     }
+    
+    public struct HexColor: Sendable {
+      public static let _006F9D = DesignKitAsset.Colors._006F9D.swiftUIColor
+      public static let _9Fd5Fb = DesignKitAsset.Colors._9Fd5Fb.swiftUIColor
+      public static let _E0F2Ff = DesignKitAsset.Colors.e0F2Ff.swiftUIColor
+    }
   }
 }
 

--- a/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
+++ b/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
@@ -54,6 +54,18 @@ public extension PetRepository {
           throw CacheError.fileNotFound /// 이 때, api 호출 필요
         }
         return PetSeasonInfoEntity(hitData)
+      },
+      getPetHistoryInfo: {
+        let endpoint = PetEndpoint.getPetHistoryInfo()
+        let entity = try await networker.execute(with: endpoint).toEntity()
+        
+//        let cacheKey = MyPetCacheKey.myPetHistoryInfo
+//        let cache = try await CacheActor.shared.MY_PET_HISTORY_INFO_CACHE
+//        let cacheModel = entity.makeCacheModel()
+        
+//        await cache.remove(forKey: cacheKey)
+//        try await cache.insert(cacheModel, forKey: cacheKey)
+        return entity
       }
     )
   }

--- a/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
+++ b/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
@@ -59,13 +59,21 @@ public extension PetRepository {
         let endpoint = PetEndpoint.getPetHistoryInfo()
         let entity = try await networker.execute(with: endpoint).toEntity()
         
-//        let cacheKey = MyPetCacheKey.myPetHistoryInfo
-//        let cache = try await CacheActor.shared.MY_PET_HISTORY_INFO_CACHE
-//        let cacheModel = entity.makeCacheModel()
+        let cacheKey = MyPetCacheKey.myPetHistoryInfo
+        let cache = try await CacheActor.shared.MY_PET_HISTORY_INFO_CACHE
+        let cacheModel = entity.makeCacheModel()
         
-//        await cache.remove(forKey: cacheKey)
-//        try await cache.insert(cacheModel, forKey: cacheKey)
+        await cache.remove(forKey: cacheKey)
+        try await cache.insert(cacheModel, forKey: cacheKey)
         return entity
+      },
+      getPetHistoryInfoFromCache: {
+        let cacheKey = MyPetCacheKey.myPetHistoryInfo
+        let cache = try await CacheActor.shared.MY_PET_HISTORY_INFO_CACHE
+        guard let hitData = await cache.value(forKey: cacheKey) else {
+          throw CacheError.fileNotFound /// 이 때, api 호출 필요
+        }
+        return PetHistoryInfoEntity(hitData)
       }
     )
   }

--- a/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetHistoryInfoDTO.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/DTO/PetHistoryInfoDTO.swift
@@ -1,0 +1,40 @@
+//
+//  PetHistoryInfoDTO.swift
+//  PetDataInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import PetDomainInterface
+import NetworkKit
+
+public struct PetHistoryInfoDTO: DTO {
+  public typealias Entity = PetHistoryInfoEntity
+  
+  public let list: [List]
+  
+  public struct List: Codable, Sendable {
+    public let userId: Int
+    public let nickname: String
+    public let point: Int
+    public let levelType: String
+    public let season: String
+    public let createdAt: String
+  }
+}
+
+public extension PetHistoryInfoDTO {
+  func toEntity() -> Entity {
+    let historyEntities = list.map { item -> PetHistoryEachInfo in
+      return .init(
+        nickname: item.nickname,
+        point: item.point,
+        levelType: item.levelType,
+        season: item.season
+      )
+    }
+    return PetHistoryInfoEntity(petHistory: historyEntities)
+  }
+}

--- a/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
@@ -30,4 +30,13 @@ public enum PetEndpoint: Sendable {
       parameters: .none
     )
   }
+  
+  public static func getPetHistoryInfo() -> Endpoint<PetHistoryInfoDTO> {
+    return Endpoint(
+      headers: .authorization(UserDefaultsKeys.accessToken),
+      method: .get,
+      path: "/pets/history",
+      parameters: .none
+    )
+  }
 }

--- a/Projects/Domain/Pet/PetDomain/Sources/FetchPetHistoryInfoUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/FetchPetHistoryInfoUseCaseImpl.swift
@@ -1,0 +1,30 @@
+//
+//  FetchPetHistoryInfoUseCaseImpl.swift
+//  PetDomain
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Utility
+import PetDomainInterface
+
+extension FetchPetHistoryInfoUseCase {
+  public static func live(repository: PetRepository) -> FetchPetHistoryInfoUseCase {
+    .init {
+      do {
+//        let entity = try await repository.getPetHistoryInfoFromCache()
+        let entity = try await repository.getPetHistoryInfo()
+        return entity
+      } catch let error as CacheError {
+        switch error {
+        case .fileNotFound:
+          let newEntity = try await repository.getPetHistoryInfo()
+          return newEntity
+        default : throw error
+        }
+      }
+    }
+  }
+}

--- a/Projects/Domain/Pet/PetDomain/Sources/FetchPetHistoryInfoUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/FetchPetHistoryInfoUseCaseImpl.swift
@@ -14,8 +14,7 @@ extension FetchPetHistoryInfoUseCase {
   public static func live(repository: PetRepository) -> FetchPetHistoryInfoUseCase {
     .init {
       do {
-//        let entity = try await repository.getPetHistoryInfoFromCache()
-        let entity = try await repository.getPetHistoryInfo()
+        let entity = try await repository.getPetHistoryInfoFromCache()
         return entity
       } catch let error as CacheError {
         switch error {

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/FetchPetHistoryInfoUseCaseKey.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/FetchPetHistoryInfoUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  FetchPetHistoryInfoUseCaseKey.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum FetchPetHistoryInfoUseCaseKey: DependencyKey {
+  public static var liveValue: FetchPetHistoryInfoUseCase { FetchPetHistoryInfoUseCaseProvider() }
+  public static var previewValue: FetchPetHistoryInfoUseCase { FetchPetHistoryInfoUseCaseProvider() }
+  public static var testValue: FetchPetHistoryInfoUseCase { FetchPetHistoryInfoUseCaseProvider() }
+}
+
+private var FetchPetHistoryInfoUseCaseProvider: () -> FetchPetHistoryInfoUseCase = {
+  fatalError("PetUseCase Dependency not configured")
+}
+
+public func FetchPetHistoryInfoUseCaseRegister(
+  provider: @escaping () -> FetchPetHistoryInfoUseCase
+) {
+  FetchPetHistoryInfoUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var FetchPetHistoryInfoUseCase: FetchPetHistoryInfoUseCase {
+    get { self[FetchPetHistoryInfoUseCaseKey.self] }
+    set { self[FetchPetHistoryInfoUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetHistoryInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetHistoryInfoEntity.swift
@@ -20,8 +20,16 @@ public struct PetHistoryInfoEntity: Sendable, Equatable {
     self.petHistory = petHistory
   }
   
-  public func makeCacheModel() {
-    
+  public init(
+    _ cacheModel: MyPetHistoryInfoCacheModel
+  ) {
+    self.petHistory = cacheModel.historyInfo.map { PetHistoryEachInfo($0) }
+  }
+  
+  public func makeCacheModel() -> MyPetHistoryInfoCacheModel {
+    return MyPetHistoryInfoCacheModel(
+      petHistory.map { $0.makeCacheModel($0) }
+    )
   }
 }
 
@@ -41,5 +49,25 @@ public struct PetHistoryEachInfo: Sendable, Equatable {
     self.point = point
     self.levelType = CatLevel(rawValue: levelType) ?? .level1
     self.season = CatType(rawValue: season) ?? ._2025_07
+  }
+  
+  public init(
+    _ cacheModel: PetHistoryEachCacheModel
+  ) {
+    self.init(
+      nickname: cacheModel.nickname,
+      point: cacheModel.point,
+      levelType: cacheModel.levelType,
+      season: cacheModel.season
+    )
+  }
+  
+  fileprivate func makeCacheModel(_ data: Self) -> PetHistoryEachCacheModel {
+    return PetHistoryEachCacheModel(
+      nickname: data.nickname,
+      point: data.point,
+      levelType: data.levelType.rawValue,
+      season: data.season.rawValue
+    )
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetHistoryInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetHistoryInfoEntity.swift
@@ -1,0 +1,45 @@
+//
+//  PetHistoryInfoEntity.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import DesignKit
+import Cache
+
+public struct PetHistoryInfoEntity: Sendable, Equatable {
+  
+  public let petHistory: [PetHistoryEachInfo] /// 고양이 시즌별 정보
+  
+  public init(
+    petHistory: [PetHistoryEachInfo]
+  ) {
+    self.petHistory = petHistory
+  }
+  
+  public func makeCacheModel() {
+    
+  }
+}
+
+public struct PetHistoryEachInfo: Sendable, Equatable {
+  public let nickname: String /// 해당 시즌의 고양이 이름 (관형사 포함)
+  public let point: Int /// 해당 시즌의 고양이 포인트
+  public let levelType: CatLevel /// 해당 레벨의 타입
+  public let season: CatType /// 현재 시즌 이름 (ex. `basic`)
+  
+  public init(
+    nickname: String,
+    point: Int,
+    levelType: String,
+    season: String
+  ) {
+    self.nickname = nickname
+    self.point = point
+    self.levelType = CatLevel(rawValue: levelType) ?? .level1
+    self.season = CatType(rawValue: season) ?? ._2025_07
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Entity/PetSeasonInfoEntity.swift
@@ -26,7 +26,8 @@ public struct PetSeasonInfoEntity: Sendable, Equatable {
   }
   
   public func makeCacheModel() -> MyPetSeasonInfoCacheModel {
-    return MyPetSeasonInfoCacheModel(seasonPetInfo.map { $0.makeCacheModel($0) }
+    return MyPetSeasonInfoCacheModel(
+      seasonPetInfo.map { $0.makeCacheModel($0) }
     )
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
@@ -16,18 +16,21 @@ public struct PetRepository {
   public var getPetSeasonInfo: @Sendable () async throws -> PetSeasonInfoEntity
   public var getPetSeasonInfoFromCache: @Sendable () async throws -> PetSeasonInfoEntity
   public var getPetHistoryInfo: @Sendable () async throws -> PetHistoryInfoEntity
+  public var getPetHistoryInfoFromCache: @Sendable () async throws -> PetHistoryInfoEntity
 
   public init(
     getPetInfo: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetInfoFromCache: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetSeasonInfo: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
     getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
-    getPetHistoryInfo: @Sendable @escaping () async throws -> PetHistoryInfoEntity
+    getPetHistoryInfo: @Sendable @escaping () async throws -> PetHistoryInfoEntity,
+    getPetHistoryInfoFromCache: @Sendable @escaping () async throws -> PetHistoryInfoEntity
   ) {
     self.getPetInfo = getPetInfo
     self.getPetInfoFromCache = getPetInfoFromCache
     self.getPetSeasonInfo = getPetSeasonInfo
     self.getPetSeasonInfoFromCache = getPetSeasonInfoFromCache
     self.getPetHistoryInfo = getPetHistoryInfo
+    self.getPetHistoryInfoFromCache = getPetHistoryInfoFromCache
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
@@ -15,16 +15,19 @@ public struct PetRepository {
   public var getPetInfoFromCache: @Sendable () async throws -> PetInfoEntity
   public var getPetSeasonInfo: @Sendable () async throws -> PetSeasonInfoEntity
   public var getPetSeasonInfoFromCache: @Sendable () async throws -> PetSeasonInfoEntity
+  public var getPetHistoryInfo: @Sendable () async throws -> PetHistoryInfoEntity
 
   public init(
     getPetInfo: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetInfoFromCache: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetSeasonInfo: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
-    getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity
+    getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
+    getPetHistoryInfo: @Sendable @escaping () async throws -> PetHistoryInfoEntity
   ) {
     self.getPetInfo = getPetInfo
     self.getPetInfoFromCache = getPetInfoFromCache
     self.getPetSeasonInfo = getPetSeasonInfo
     self.getPetSeasonInfoFromCache = getPetSeasonInfoFromCache
+    self.getPetHistoryInfo = getPetHistoryInfo
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/FetchPetHistoryInfoUseCase.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/FetchPetHistoryInfoUseCase.swift
@@ -1,0 +1,17 @@
+//
+//  FetchPetHistoryInfoUseCase.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct FetchPetHistoryInfoUseCase {
+  public var execute: @Sendable () async throws -> PetHistoryInfoEntity
+  
+  public init(execute: @Sendable @escaping () async throws -> PetHistoryInfoEntity) {
+    self.execute = execute
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetDetailFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetDetailFeature.swift
@@ -8,7 +8,7 @@
 
 import SwiftUI
 import ComposableArchitecture
-import UserDefaults
+import Utility
 import AuthFeature
 
 @Reducer
@@ -18,11 +18,49 @@ public struct MyPetDetailFeature {
   
   @ObservableState
   public struct State: Equatable {
+    
+    public var catHistoryCard: [CatHistoryCardRecord] = [
+      CatHistoryCardRecord(
+        nickname: "너무 너무 너무나 고양이",
+        imageURL: "type:basic_3, interaction:true",
+        levelType: .level3
+      ),
+      CatHistoryCardRecord(
+        nickname: "응애 고양이",
+        imageURL: "type:basic_1, interaction:true",
+        levelType: .level1
+      ),
+      CatHistoryCardRecord(
+        nickname: "응애 응우앤 고양이",
+        imageURL: "type:basic_5, interaction:false",
+        levelType: .level5
+      ),
+      CatHistoryCardRecord(
+        nickname: "응애 응우앤 고양이",
+        imageURL: "type:basic_5, interaction:false",
+        levelType: .level5
+      ),
+      CatHistoryCardRecord(
+        nickname: "응애 응우앤 고양이",
+        imageURL: "type:basic_5, interaction:false",
+        levelType: .level5
+      ),
+      CatHistoryCardRecord(
+        nickname: "응애 응우앤 고양이",
+        imageURL: "type:basic_5, interaction:false",
+        levelType: .level5
+      )
+    ]
+    
     public init() {}
   }
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
+    case willFetchPetHistoryInfo
+    case fetchPetHistoryInfo([CatHistoryCardRecord])
+    case fetchPetHistoryInfoResult(Result<[CatHistoryCardRecord], NetworkError>)
+    
     case backButtonTapped
     case pop
   }
@@ -31,10 +69,21 @@ public struct MyPetDetailFeature {
     BindingReducer()
     Reduce { state, action in
       switch action {
+      case .willFetchPetHistoryInfo:
+        return fetchPetHistoryInfo()
+      case let .fetchPetHistoryInfo(records):
+        state.catHistoryCard = records
+        return .none
       case .backButtonTapped:
         return .send(.pop)
       default: return .none
       }
     }
+  }
+}
+
+extension MyPetDetailFeature {
+  fileprivate func fetchPetHistoryInfo() -> Effect<Action> {
+    return .none
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetDetailFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetDetailFeature.swift
@@ -9,7 +9,9 @@
 import SwiftUI
 import ComposableArchitecture
 import Utility
-import AuthFeature
+import DesignKit
+
+import PetDomainInterface
 
 @Reducer
 public struct MyPetDetailFeature {
@@ -19,38 +21,7 @@ public struct MyPetDetailFeature {
   @ObservableState
   public struct State: Equatable {
     
-    public var catHistoryCard: [CatHistoryCardRecord] = [
-      CatHistoryCardRecord(
-        nickname: "너무 너무 너무나 고양이",
-        imageURL: "type:basic_3, interaction:true",
-        levelType: .level3
-      ),
-      CatHistoryCardRecord(
-        nickname: "응애 고양이",
-        imageURL: "type:basic_1, interaction:true",
-        levelType: .level1
-      ),
-      CatHistoryCardRecord(
-        nickname: "응애 응우앤 고양이",
-        imageURL: "type:basic_5, interaction:false",
-        levelType: .level5
-      ),
-      CatHistoryCardRecord(
-        nickname: "응애 응우앤 고양이",
-        imageURL: "type:basic_5, interaction:false",
-        levelType: .level5
-      ),
-      CatHistoryCardRecord(
-        nickname: "응애 응우앤 고양이",
-        imageURL: "type:basic_5, interaction:false",
-        levelType: .level5
-      ),
-      CatHistoryCardRecord(
-        nickname: "응애 응우앤 고양이",
-        imageURL: "type:basic_5, interaction:false",
-        levelType: .level5
-      )
-    ]
+    public var catHistoryCard: [CatHistoryCardRecord] = []
     
     public init() {}
   }
@@ -59,21 +30,33 @@ public struct MyPetDetailFeature {
     case binding(BindingAction<State>)
     case willFetchPetHistoryInfo
     case fetchPetHistoryInfo([CatHistoryCardRecord])
-    case fetchPetHistoryInfoResult(Result<[CatHistoryCardRecord], NetworkError>)
+    case fetchPetHistoryInfoResult(Result<PetHistoryInfoEntity, NetworkError>)
     
     case backButtonTapped
     case pop
   }
+  
+  @Dependency(\.FetchPetHistoryInfoUseCase) var fetchPetHistoryInfoUseCase
   
   public var body: some ReducerOf<Self> {
     BindingReducer()
     Reduce { state, action in
       switch action {
       case .willFetchPetHistoryInfo:
-        return fetchPetHistoryInfo()
+        return fetchPetHistoryInfo(fetchPetHistoryInfoUseCase)
+        
+      case let .fetchPetHistoryInfoResult(result):
+        switch result {
+        case let .success(records):
+          return .send(fetchRealPetHistoryInfo(with: records))
+        case let .failure(error):
+          return .none
+        }
+        
       case let .fetchPetHistoryInfo(records):
         state.catHistoryCard = records
         return .none
+        
       case .backButtonTapped:
         return .send(.pop)
       default: return .none
@@ -83,7 +66,31 @@ public struct MyPetDetailFeature {
 }
 
 extension MyPetDetailFeature {
-  fileprivate func fetchPetHistoryInfo() -> Effect<Action> {
-    return .none
+  fileprivate func fetchPetHistoryInfo(
+    _ useCase: FetchPetHistoryInfoUseCase
+  ) -> Effect<Action> {
+    .run { send in
+      do {
+        let entity = try await useCase.execute()
+        await send(.fetchPetHistoryInfoResult(.success(entity)))
+      } catch is CancellationError {
+        await send(.fetchPetHistoryInfoResult(.failure(.taskCancelled)))
+      } catch {
+        await send(.fetchPetHistoryInfoResult(.failure(.customError(message: error.localizedDescription))))
+      }
+    }
+  }
+  
+  fileprivate func fetchRealPetHistoryInfo(
+    with historyInfo: PetHistoryInfoEntity
+  ) -> Action {
+    let records = historyInfo.petHistory.map { item -> CatHistoryCardRecord in
+      let imageURL = CatImageSet.imageURL(
+        level: item.levelType,
+        type: item.season
+      )
+      return .init(nickname: item.nickname, imageURL: imageURL, levelType: item.levelType)
+    }
+    return .fetchPetHistoryInfo(records)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -33,8 +33,8 @@ public struct CatCardCell: View {
             )
           } else {
             VStack(spacing: 0) {
-              Color(hex: "E0F2FF")
-              Color(hex: "9FD5FB")
+              ColorSet.HexColor._E0F2Ff
+              ColorSet.HexColor._9Fd5Fb
             }
             CatImageSet.image(name: card.imageURL)
               .resizable()

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -19,11 +19,11 @@ public struct CatCardCell: View {
   }
   
   public var body: some View {
-    RoundedRectangle(cornerRadius: .Number8)
+    Rectangle()
       .fill(card.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
       .frame(width: .Number64, height: .Number64)
       .overlay(
-        Group {
+        ZStack {
           if card.isLocked {
             Icon(
               image: .lock,
@@ -32,12 +32,17 @@ public struct CatCardCell: View {
               color: ColorSet.Icon.Tertiary
             )
           } else {
+            VStack(spacing: 0) {
+              Color(hex: "E0F2FF")
+              Color(hex: "9FD5FB")
+            }
             CatImageSet.image(name: card.imageURL)
               .resizable()
               .scaledToFit()
           }
         }
       )
+      .clipCorners(.Number8, corners: .allCorners)
       .opacity(card.isLocked ? 0.4 : 1.0)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatHistoryCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatHistoryCardCell.swift
@@ -1,0 +1,86 @@
+//
+//  CatHistoryCardCell.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import Utility
+import DesignKit
+
+public struct CatHistoryCardCell: View {
+  public let record: CatHistoryCardRecord
+  
+  public init(
+    record: CatHistoryCardRecord
+  ) {
+    self.record = record
+  }
+  
+  public var body: some View {
+    VStack(alignment: .center, spacing: .Number10) {
+      CatCard
+        .aspectRatio(1, contentMode: .fit)
+      CatCardInfo
+    }
+    .padding(.horizontal, .Number8)
+    .padding(.top, .Number8)
+    .padding(.bottom, .Number12)
+    .background(
+      RoundedRectangle(cornerRadius: .Number8)
+        .inset(by: .Number1)
+        .stroke(ColorSet.Border.Secondary, lineWidth: .Number1)
+        .fill(ColorSet.Background.Primary)
+    ) 
+  }
+  
+  @ViewBuilder
+  private var CatCard: some View {
+    Rectangle()
+      .overlay(
+        ZStack {
+          VStack(spacing: 0) {
+            Color(hex: "E0F2FF")
+            Color(hex: "9FD5FB")
+          }
+          CatImageSet.image(name: record.imageURL)
+            .resizable()
+            .scaledToFit()
+            .padding(.Number14)
+        }
+      )
+      .clipCorners(.Number8, corners: .allCorners)
+  }
+  
+  @ViewBuilder
+  private var CatCardInfo: some View {
+    VStack(alignment: .center, spacing: .Number6) {
+      Badge(
+        text: .constant("Lv.\(record.levelType.rawInt)"),
+        state: .primary
+      )
+      CatNicknameView(nickname: record.nickname)
+    }
+  }
+  
+  @ViewBuilder
+  private func CatNicknameView(
+    nickname: String
+  ) -> some View {
+    let splitNickname = nickname.splitNicknameForTwoLines()
+    if let secondLine = splitNickname.second {
+      Text(splitNickname.first + "\n" + secondLine)
+        .font(FontSet.Title.title4)
+        .foregroundStyle(ColorSet.Text.Primary)
+        .multilineTextAlignment(.center)
+    } else {
+      Text(splitNickname.first)
+        .font(FontSet.Title.title4)
+        .foregroundStyle(ColorSet.Text.Primary)
+        .multilineTextAlignment(.center)
+    }
+  }
+}
+

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatHistoryCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatHistoryCardCell.swift
@@ -42,8 +42,8 @@ public struct CatHistoryCardCell: View {
       .overlay(
         ZStack {
           VStack(spacing: 0) {
-            Color(hex: "E0F2FF")
-            Color(hex: "9FD5FB")
+            ColorSet.HexColor._E0F2Ff
+            ColorSet.HexColor._9Fd5Fb
           }
           CatImageSet.image(name: record.imageURL)
             .resizable()

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -36,8 +36,8 @@ public struct GrowthRecordCell: View {
                 )
               } else {
                 VStack(spacing: 0) {
-                  Color(hex: "E0F2FF")
-                  Color(hex: "9FD5FB")
+                  ColorSet.HexColor._E0F2Ff
+                  ColorSet.HexColor._9Fd5Fb
                 }
                 CatImageSet.image(name: record.catCard.imageURL)
                   .resizable()

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -22,11 +22,11 @@ public struct GrowthRecordCell: View {
     HStack(alignment: .center, spacing: .Number16) {
       HStack(alignment: .center, spacing: .Number12) {
         // 썸네일 이미지
-        RoundedRectangle(cornerRadius: .Number8)
+        Rectangle()
           .fill(record.catCard.isLocked ? ColorSet.Background.Tertiary : ColorSet.Gray._100)
           .frame(width: .Number64, height: .Number64)
           .overlay(
-            Group {
+            ZStack {
               if record.catCard.isLocked {
                 Icon(
                   image: .lock,
@@ -35,12 +35,17 @@ public struct GrowthRecordCell: View {
                   color: ColorSet.Icon.Tertiary
                 )
               } else {
+                VStack(spacing: 0) {
+                  Color(hex: "E0F2FF")
+                  Color(hex: "9FD5FB")
+                }
                 CatImageSet.image(name: record.catCard.imageURL)
                   .resizable()
                   .scaledToFit()
               }
             }
           )
+          .clipCorners(.Number8, corners: .allCorners)
         
         // 정보 영역
         VStack(alignment: .leading, spacing: .Number4) {

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatHistoryCardRecord.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ListModel/CatHistoryCardRecord.swift
@@ -1,0 +1,28 @@
+//
+//  CatHistoryCardRecord.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import Utility
+import DesignKit
+
+public struct CatHistoryCardRecord: Identifiable, Equatable {
+  public let id = UUID()
+  public let nickname: String
+  public let levelType: CatLevel /// 고양이 레벨 타입
+  public let imageURL: String /// 고양이 이미지 URL
+  
+  public init(
+    nickname: String,
+    imageURL: String,
+    levelType: CatLevel
+  ) {
+    self.nickname = nickname
+    self.imageURL = imageURL
+    self.levelType = levelType
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
@@ -36,7 +36,8 @@ public struct MyPetDetailView: View {
         TouchArea(image: .leftChevron) {
           store.send(.backButtonTapped)
         }
-      }
+      },
+      title: "내가 돌본 펫"
     )
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
@@ -25,6 +25,9 @@ public struct MyPetDetailView: View {
     }
     .background(ColorSet.Background.Primary)
     .navigationBarBackButtonHidden(true)
+    .onAppear() {
+      store.send(.willFetchPetHistoryInfo)
+    }
   }
   
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetDetailView.swift
@@ -21,7 +21,7 @@ public struct MyPetDetailView: View {
   public var body: some View {
     VStack {
       navigationBar
-      Spacer()
+      PetHistoryGridView
     }
     .background(ColorSet.Background.Primary)
     .navigationBarBackButtonHidden(true)
@@ -38,6 +38,34 @@ public struct MyPetDetailView: View {
         }
       },
       title: "내가 돌본 펫"
+    )
+  }
+  
+  @ViewBuilder
+  private var PetHistoryGridView: some View {
+    ScrollView {
+      LazyVGrid(
+        columns: [GridItem(.flexible()), GridItem(.flexible())],
+        spacing: .Number12
+      ) {
+        ForEach(store.catHistoryCard) { record in
+          CatHistoryCardCell(record: record)
+        }
+      }
+      .padding(.horizontal, .Number16)
+      .padding(.top, .Number16)
+    }
+    .background(
+      LinearGradient(
+        gradient: Gradient(
+          colors: [
+            ColorSet.Background.Primary,
+            ColorSet.Background.Tertiary
+          ]
+        ),
+        startPoint: .top,
+        endPoint: .bottom
+      )
     )
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -92,8 +92,8 @@ public struct MyPetView: View {
               .fill(
                 RadialGradient(
                   gradient: Gradient(stops: [
-                    .init(color: Color(hex: "#006F9D").opacity(0.3), location: 0),
-                    .init(color: Color(hex: "#006F9D").opacity(0), location: 1)
+                    .init(color: ColorSet.HexColor._006F9D.opacity(0.3), location: 0),
+                    .init(color: ColorSet.HexColor._006F9D.opacity(0), location: 1)
                   ]),
                   center: .center,
                   startRadius: 0,

--- a/Projects/Shared/Utility/Sources/Extension/String+.swift
+++ b/Projects/Shared/Utility/Sources/Extension/String+.swift
@@ -48,4 +48,18 @@ extension String {
     formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
     return formatter.date(from: self)
   }
+  
+  /// 닉네임을 마지막 띄어쓰기를 기준으로 두 줄로 분리
+  ///
+  /// - Returns: (첫째줄, 둘째줄) 튜플. 띄어쓰기가 없으면 (전체, nil) 반환
+  public func splitNicknameForTwoLines() -> (first: String, second: String?) {
+    let words = self.split(separator: " ").map{ String($0) }
+    guard words.count > 1 else {
+      return (words.first!, nil)
+    }
+    
+    let lastWord = words.last!
+    let firstPart = words.dropLast().joined(separator: " ")
+    return (firstPart, lastWord)
+  }
 }

--- a/Projects/Sseudam/Sources/DependencyRegister.swift
+++ b/Projects/Sseudam/Sources/DependencyRegister.swift
@@ -157,6 +157,7 @@ struct DependencyRegister {
       FetchTrashSpotRawDetailUseCase.live(repository: trashSpotRepository)
     }
     
+    // MARK: - Pet
     CheckPetInfoUseCaseRegister {
       CheckPetInfoUseCase.live(repository: petRepository)
     }
@@ -164,6 +165,11 @@ struct DependencyRegister {
     FetchPetSeasonInfoUseCaseRegister {
       FetchPetSeasonInfoUseCase.live(repository: petRepository)
     }
+    
+    FetchPetHistoryInfoUseCaseRegister {
+      FetchPetHistoryInfoUseCase.live(repository: petRepository)
+    }
+    
     // MARK: - Visited
     
     VisitedUseCaseRegister {


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #60 

## 🔎 작업 내용
- 마이펫 디테일 페이지 작업
- UI구현 및 API연동 완료
- 캐싱정책을 적용했고, TTL은 .high로 적용 (10분)

## 📷 스크린샷
https://github.com/user-attachments/assets/42d4c4c9-646d-4316-9277-7de7ffac2758

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for fetching and displaying pet history information, including a new grid view of pet history cards in the My Pet Detail screen.
  * Introduced a new pet history card cell UI for visualizing each pet's history.
  * Added a new use case for retrieving pet history, with cache-first logic and fallback to network fetch.
  * Enabled dependency injection for the pet history fetch use case.

* **Enhancements**
  * Improved nickname display by splitting long nicknames into two lines for better readability.
  * Updated UI components to use gradient backgrounds and consistent corner clipping for a more polished look.
  * Enhanced navigation bar with a new title on the My Pet Detail view.

* **Chores**
  * Registered the new pet history fetch use case in the dependency injection system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->