### PR TITLE
feat: #61 마이펫 닉네임 변경 UI 및 API 연동

### DIFF
--- a/Projects/Core/Cache/Sources/CacheActor.swift
+++ b/Projects/Core/Cache/Sources/CacheActor.swift
@@ -55,7 +55,7 @@ extension CacheActor {
     get async throws {
       return try await cache(
         .myPetInfo,
-        ttl: .high,
+        ttl: .low,
         eviction: .none
       )
     }
@@ -65,7 +65,7 @@ extension CacheActor {
     get async throws {
       return try await cache(
         .myPetSeasonInfo,
-        ttl: .high,
+        ttl: .low,
         eviction: .none
       )
     }

--- a/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
+++ b/Projects/Data/Pet/PetData/Sources/PetRepositoryImpl.swift
@@ -54,6 +54,10 @@ public extension PetRepository {
           throw CacheError.fileNotFound /// 이 때, api 호출 필요
         }
         return PetSeasonInfoEntity(hitData)
+      },
+      putPetNickname: { nickname in
+        let endpoint = PetEndpoint.putPetNickname(nickname)
+        let result = try await networker.execute(with: endpoint)
       }
     )
   }

--- a/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
+++ b/Projects/Data/Pet/PetDataInterface/Sources/Endpoint/PetEndpoint.swift
@@ -30,4 +30,13 @@ public enum PetEndpoint: Sendable {
       parameters: .none
     )
   }
+  
+  public static func putPetNickname(_ nickname: String) -> Endpoint<EmptyResponse> {
+    return Endpoint(
+      headers: .authorization(UserDefaultsKeys.accessToken),
+      method: .put,
+      path: "/pets/name",
+      parameters: .body(["nickname": nickname])
+    )
+  }
 }

--- a/Projects/Domain/Pet/PetDomain/Sources/ChangePetNicknameUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/ChangePetNicknameUseCaseImpl.swift
@@ -1,0 +1,23 @@
+//
+//  ChangePetNicknameUseCaseImpl.swift
+//  PetDomain
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Utility
+import PetDomainInterface
+
+extension ChangePetNicknameUseCase {
+  public static func live(repository: PetRepository) -> ChangePetNicknameUseCase {
+    .init { nickname in
+      do {
+        try await repository.putPetNickname(nickname)
+      } catch let error as NetworkError {
+        throw error
+      }
+    }
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/ChangePetNicknameUseCaseKey.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/DependencyKey/ChangePetNicknameUseCaseKey.swift
@@ -1,0 +1,33 @@
+//
+//  ChangePetNicknameUseCaseKey.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import Dependencies
+
+public enum ChangePetNicknameUseCaseKey: DependencyKey {
+  public static var liveValue: ChangePetNicknameUseCase { ChangePetNicknameUseCaseProvider() }
+  public static var previewValue: ChangePetNicknameUseCase { ChangePetNicknameUseCaseProvider() }
+  public static var testValue: ChangePetNicknameUseCase { ChangePetNicknameUseCaseProvider() }
+}
+
+private var ChangePetNicknameUseCaseProvider: () -> ChangePetNicknameUseCase = {
+  fatalError("PetUseCase Dependency not configured")
+}
+
+public func ChangePetNicknameUseCaseRegister(
+  provider: @escaping () -> ChangePetNicknameUseCase
+) {
+  ChangePetNicknameUseCaseProvider = provider
+}
+
+extension DependencyValues {
+  public var ChangePetNicknameUseCase: ChangePetNicknameUseCase {
+    get { self[ChangePetNicknameUseCaseKey.self] }
+    set { self[ChangePetNicknameUseCaseKey.self] = newValue }
+  }
+}

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/Repository/PetRepository.swift
@@ -15,16 +15,19 @@ public struct PetRepository {
   public var getPetInfoFromCache: @Sendable () async throws -> PetInfoEntity
   public var getPetSeasonInfo: @Sendable () async throws -> PetSeasonInfoEntity
   public var getPetSeasonInfoFromCache: @Sendable () async throws -> PetSeasonInfoEntity
+  public var putPetNickname: @Sendable (String) async throws -> Void
 
   public init(
     getPetInfo: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetInfoFromCache: @Sendable @escaping () async throws -> PetInfoEntity,
     getPetSeasonInfo: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
-    getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity
+    getPetSeasonInfoFromCache: @Sendable @escaping () async throws -> PetSeasonInfoEntity,
+    putPetNickname: @Sendable @escaping (String) async throws -> Void
   ) {
     self.getPetInfo = getPetInfo
     self.getPetInfoFromCache = getPetInfoFromCache
     self.getPetSeasonInfo = getPetSeasonInfo
     self.getPetSeasonInfoFromCache = getPetSeasonInfoFromCache
+    self.putPetNickname = putPetNickname
   }
 }

--- a/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/ChangePetNicknameUseCase.swift
+++ b/Projects/Domain/Pet/PetDomainInterface/Sources/UseCases/ChangePetNicknameUseCase.swift
@@ -1,0 +1,19 @@
+//
+//  ChangePetNicknameUseCase.swift
+//  PetDomainInterface
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct ChangePetNicknameUseCase {
+  public var execute: @Sendable (String) async throws -> Void
+  
+  public init(
+    execute: @Sendable @escaping (String) async throws -> Void
+  ) {
+    self.execute = execute
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
@@ -105,13 +105,16 @@ public struct ChangeMyPetNicknameFeature {
   
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
-    case backButtonTapped
-    case pop
-    case focusChanged(Bool)
     case delegate(Delegate)
+    case focusChanged(Bool)
+    
+    case setButtonState(Bool)
     
     case changeNicknameButtonTapped
     case changeNicknameButtonTappedResult(Result<String, NetworkError>)
+    
+    case backButtonTapped
+    case pop
     
     public enum Delegate: Equatable {
       case didChangeNickname
@@ -125,13 +128,12 @@ public struct ChangeMyPetNicknameFeature {
     Reduce { state, action in
       switch action {
       case .binding(\.name):
-        state.validationResult = validateNameInput(
-          state.name,
-          initName: state.initName
-        )
-        state.buttonState = state.validationResult.isButtonEnabled
-        ? .normal
-        : .disabled
+        state.validationResult = validateNameInput(state.name, state.initName)
+        let isButtonEnabled = state.validationResult.isButtonEnabled
+        return .send(.setButtonState(isButtonEnabled))
+        
+      case let .setButtonState(isEnabled):
+        state.buttonState = isEnabled ? .normal : .disabled
         return .none
         
       case let .focusChanged(isFocused):
@@ -185,7 +187,7 @@ extension ChangeMyPetNicknameFeature {
   /// 우선순위: error1(길이 부족) > error2(길이 초과) > error3(특수문자/이모지) > error4(공백으로 시작)
   private func validateNameInput(
     _ name: String,
-    initName: String?
+    _ initName: String?
   ) -> NameValidationResult {
     if name == initName { return .equalInitName }
     /// 빈 문자열

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
@@ -1,0 +1,202 @@
+//
+//  ChangeMyPetNicknameFeature.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignKit
+import Utility
+import PetDomainInterface
+
+@Reducer
+public struct ChangeMyPetNicknameFeature {
+  
+  public init() {}
+  
+  /// 닉네임 유효성 검사 결과
+  public enum NameValidationResult: Equatable {
+    case valid
+    case equelInitName      // 초기 이름과 동일한 경우
+    case tooShort           // error1: 0~1자 일때
+    case tooLong            // error2: 13자 이상일때
+    case startsWithSpace    // error4: 공백으로 시작
+    case serverError(String?)        // 서버 통신 과정에서 오류
+    case empty              // 초기 상태
+    
+    /// 에러 메시지 반환
+    var message: String {
+      switch self {
+      case .valid:
+        return "사용 가능한 고양이 이름이에요."
+      case .equelInitName:
+        return ""
+      case .tooShort:
+        return "고양이 이름은 2자 이상 입력해주세요."
+      case .tooLong:
+        return "고양이 이름은 12자 이하로 입력해주세요."
+      case .startsWithSpace:
+        return "고양이 이름은 공백으로 시작할 수 없어요."
+      case let .serverError(errorMessage):
+        return errorMessage ?? self.defaultErrorMessage
+      case .empty:
+        return "2~12자까지 입력할 수 있어요."
+      }
+    }
+    
+    var defaultErrorMessage: String { return "서버 통신에 실패했어요. 잠시 후 다시 시도해주세요." }
+    
+    /// TextField 상태 반환
+    var textFieldState: CustomTextFieldState {
+      switch self {
+      case .valid:
+        return .accent
+      case .tooShort, .tooLong, .startsWithSpace, .serverError:
+        return .error
+      case .empty, .equelInitName:
+        return .normal
+      }
+    }
+    
+    /// 버튼 활성화 여부
+    var isButtonEnabled: Bool {
+      return self == .valid
+    }
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    public let initName: String
+    public var name: String
+    public var validationResult: NameValidationResult = .empty
+    public var isFocused: Bool = false
+    public var isLoading: Bool = false
+    public var buttonState: PrimaryButtonState = .disabled
+    
+    public init(
+      name: String? = nil
+    ) {
+      guard let name = name, !name.isEmpty else {
+        self.initName = ""
+        self.name = ""
+        return
+      }
+      
+      let realName = name.split(separator: " ").last.map { String($0) } ?? ""
+      
+      self.initName = realName
+      self.name = initName
+    }
+    
+    /// 현재 텍스트필드 상태
+    public var textFieldState: CustomTextFieldState {
+      validationResult.textFieldState
+    }
+    
+    /// 에러 메시지
+    public var errorMessage: String {
+      validationResult.message
+    }
+    
+  }
+  
+  public enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case backButtonTapped
+    case pop
+    case focusChanged(Bool)
+    case delegate(Delegate)
+    
+    case changeNicknameButtonTapped
+    case changeNicknameButtonTappedResult(Result<String, NetworkError>)
+    
+    public enum Delegate: Equatable {
+      case didChangeNickname
+    }
+  }
+  
+  @Dependency(\.ChangePetNicknameUseCase) var changePetNicknameUseCase
+  
+  public var body: some ReducerOf<Self> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+      case .binding(\.name):
+        state.validationResult = validateNameInput(
+          state.name,
+          initName: state.initName
+        )
+        state.buttonState = state.validationResult.isButtonEnabled
+        ? .normal
+        : .disabled
+        return .none
+        
+      case let .focusChanged(isFocused):
+        state.isFocused = isFocused
+        return .none
+        
+      case .changeNicknameButtonTapped:
+        state.isLoading = true
+        return changeNickname(name: state.name)
+
+      case let .changeNicknameButtonTappedResult(result):
+        state.isLoading = false
+        switch result {
+        case .success:
+          return .run { send in
+            await send(.delegate(.didChangeNickname))
+            await send(.pop)
+          }
+        case let .failure(error):
+          state.validationResult = .serverError(error.errorDescription)
+          state.buttonState = .disabled
+          return .none
+        }
+      case .backButtonTapped:
+        return .send(.pop)
+      default:
+        return .none
+      }
+    }
+  }
+}
+
+extension ChangeMyPetNicknameFeature {
+  
+  private func changeNickname(
+    name: String
+  ) -> Effect<Action> {
+    return .run { send in
+      do {
+        try await changePetNicknameUseCase.execute(name)
+        await send(.changeNicknameButtonTappedResult(.success(name)))
+      } catch let error as NetworkError {
+        await send(.changeNicknameButtonTappedResult(.failure(error)))
+      } catch {
+        await send(.changeNicknameButtonTappedResult(.failure(NetworkError.customError(message: error.localizedDescription))))
+      }
+    }
+  }
+  
+  /// 닉네임 유효성 검사 로직 (클라이언트 검증)
+  /// 우선순위: error1(길이 부족) > error2(길이 초과) > error3(특수문자/이모지) > error4(공백으로 시작)
+  private func validateNameInput(
+    _ name: String,
+    initName: String?
+  ) -> NameValidationResult {
+    if name == initName { return .equelInitName }
+    /// 빈 문자열
+    if name.isEmpty { return .empty}
+    /// error4: 공백으로 시작 (우선순위 4)
+    if name.hasPrefix(" ") { return .startsWithSpace }
+    /// error1: 0~1자 (우선순위 1)
+    if name.count < 2 { return .tooShort }
+    /// error2: 13자 이상 (우선순위 2)
+    if name.count > 12 { return .tooLong }
+    /// 모든 검사 통과
+    return .valid
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
@@ -20,7 +20,7 @@ public struct ChangeMyPetNicknameFeature {
   /// 닉네임 유효성 검사 결과
   public enum NameValidationResult: Equatable {
     case valid
-    case equelInitName      // 초기 이름과 동일한 경우
+    case equalInitName      // 초기 이름과 동일한 경우
     case tooShort           // error1: 0~1자 일때
     case tooLong            // error2: 13자 이상일때
     case startsWithSpace    // error4: 공백으로 시작
@@ -32,7 +32,7 @@ public struct ChangeMyPetNicknameFeature {
       switch self {
       case .valid:
         return "사용 가능한 고양이 이름이에요."
-      case .equelInitName:
+      case .equalInitName:
         return ""
       case .tooShort:
         return "고양이 이름은 2자 이상 입력해주세요."
@@ -56,7 +56,7 @@ public struct ChangeMyPetNicknameFeature {
         return .accent
       case .tooShort, .tooLong, .startsWithSpace, .serverError:
         return .error
-      case .empty, .equelInitName:
+      case .empty, .equalInitName:
         return .normal
       }
     }
@@ -187,7 +187,7 @@ extension ChangeMyPetNicknameFeature {
     _ name: String,
     initName: String?
   ) -> NameValidationResult {
-    if name == initName { return .equelInitName }
+    if name == initName { return .equalInitName }
     /// 빈 문자열
     if name.isEmpty { return .empty}
     /// error4: 공백으로 시작 (우선순위 4)

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/ChangeMyPetNicknameFeature.swift
@@ -109,6 +109,7 @@ public struct ChangeMyPetNicknameFeature {
     case focusChanged(Bool)
     
     case setButtonState(Bool)
+    case setIsLoading(Bool)
     
     case changeNicknameButtonTapped
     case changeNicknameButtonTappedResult(Result<String, NetworkError>)
@@ -141,11 +142,9 @@ public struct ChangeMyPetNicknameFeature {
         return .none
         
       case .changeNicknameButtonTapped:
-        state.isLoading = true
         return changeNickname(name: state.name)
 
       case let .changeNicknameButtonTappedResult(result):
-        state.isLoading = false
         switch result {
         case .success:
           return .run { send in
@@ -157,8 +156,10 @@ public struct ChangeMyPetNicknameFeature {
           state.buttonState = .disabled
           return .none
         }
+        
       case .backButtonTapped:
         return .send(.pop)
+        
       default:
         return .none
       }
@@ -173,12 +174,17 @@ extension ChangeMyPetNicknameFeature {
   ) -> Effect<Action> {
     return .run { send in
       do {
+        await send(.setIsLoading(true))
         try await changePetNicknameUseCase.execute(name)
         await send(.changeNicknameButtonTappedResult(.success(name)))
+        await send(.setIsLoading(false))
       } catch let error as NetworkError {
         await send(.changeNicknameButtonTappedResult(.failure(error)))
+        await send(.setIsLoading(false))
       } catch {
-        await send(.changeNicknameButtonTappedResult(.failure(NetworkError.customError(message: error.localizedDescription))))
+        let message = NetworkError.customError(message: error.localizedDescription)
+        await send(.changeNicknameButtonTappedResult(.failure(message)))
+        await send(.setIsLoading(false))
       }
     }
   }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -24,6 +24,7 @@ public struct MyPetFeature {
   public struct State {
     public var path = StackState<Path.State>()
     public var petGrowthList: MyPetGrowthListFeature.State
+    public var changePetNickname: ChangeMyPetNicknameFeature.State
     
     public var myPetInfo: PetInfoEntity?
     
@@ -44,6 +45,7 @@ public struct MyPetFeature {
     
     public init() {
       self.petGrowthList = MyPetGrowthListFeature.State()
+      self.changePetNickname = ChangeMyPetNicknameFeature.State()
     }
   }
   
@@ -51,6 +53,8 @@ public struct MyPetFeature {
     case binding(BindingAction<State>)
     case path(StackActionOf<Path>)
     case petGrowthList(MyPetGrowthListFeature.Action)
+    case changePetNickname(ChangeMyPetNicknameFeature.Action)
+    
     case onAppear
     case checkLoggedIn
     case fetchMyPetInfo
@@ -89,6 +93,9 @@ public struct MyPetFeature {
     Scope(state: \.petGrowthList, action: \.petGrowthList) {
       MyPetGrowthListFeature()
     }
+    Scope(state: \.changePetNickname, action: \.changePetNickname) {
+      ChangeMyPetNicknameFeature()
+    }
     Reduce { state, action in
       switch action {
       case .onAppear:
@@ -118,8 +125,9 @@ public struct MyPetFeature {
         state.path.append(.petDetail(MyPetDetailFeature.State()))
         return .send(.delegate(.needToHiddenTabBar(true)))
       case .petNicknameButtonTapped:
-        print("petNicknameButtonTapped")
-        return .none
+        let initName = state.myPetInfo?.nickname
+        state.path.append(.changeNickname(ChangeMyPetNicknameFeature.State(name: initName)))
+        return .send(.delegate(.needToHiddenTabBar(true)))
         
       case let .catImageTapped(location):
         /// 이전 로띠가 표시 중이면 무시
@@ -176,8 +184,21 @@ public struct MyPetFeature {
           state.path.removeLast()
           return .none
           
+        case .element(id: _, action: .changeNickname(.pop)):
+          state.path.removeLast()
+          return .none
+          
         default: return .none
         }
+        
+      case let .changePetNickname(action):
+        switch action {
+        case .delegate(.didChangeNickname):
+          return .send(.fetchMyPetInfo)
+          
+        default: break
+        }
+        return .none
         
       default: return .none
       }
@@ -207,5 +228,6 @@ extension MyPetFeature {
   @Reducer(state: .equatable, action: .equatable)
   public enum Path {
     case petDetail(MyPetDetailFeature)
+    case changeNickname(ChangeMyPetNicknameFeature)
   }
 }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetFeature.swift
@@ -24,7 +24,6 @@ public struct MyPetFeature {
   public struct State {
     public var path = StackState<Path.State>()
     public var petGrowthList: MyPetGrowthListFeature.State
-    public var changePetNickname: ChangeMyPetNicknameFeature.State
     
     public var myPetInfo: PetInfoEntity?
     
@@ -45,7 +44,6 @@ public struct MyPetFeature {
     
     public init() {
       self.petGrowthList = MyPetGrowthListFeature.State()
-      self.changePetNickname = ChangeMyPetNicknameFeature.State()
     }
   }
   
@@ -53,7 +51,6 @@ public struct MyPetFeature {
     case binding(BindingAction<State>)
     case path(StackActionOf<Path>)
     case petGrowthList(MyPetGrowthListFeature.Action)
-    case changePetNickname(ChangeMyPetNicknameFeature.Action)
     
     case onAppear
     case checkLoggedIn
@@ -92,9 +89,6 @@ public struct MyPetFeature {
     BindingReducer()
     Scope(state: \.petGrowthList, action: \.petGrowthList) {
       MyPetGrowthListFeature()
-    }
-    Scope(state: \.changePetNickname, action: \.changePetNickname) {
-      ChangeMyPetNicknameFeature()
     }
     Reduce { state, action in
       switch action {
@@ -184,21 +178,15 @@ public struct MyPetFeature {
           state.path.removeLast()
           return .none
           
+        case .element(id: _, action: .changeNickname(.delegate(.didChangeNickname))):
+          return .send(.fetchMyPetInfo)
+          
         case .element(id: _, action: .changeNickname(.pop)):
           state.path.removeLast()
           return .none
           
         default: return .none
         }
-        
-      case let .changePetNickname(action):
-        switch action {
-        case .delegate(.didChangeNickname):
-          return .send(.fetchMyPetInfo)
-          
-        default: break
-        }
-        return .none
         
       default: return .none
       }

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ChangeMyPetNicknameView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/ChangeMyPetNicknameView.swift
@@ -1,0 +1,69 @@
+//
+//  ChangeMyPetNicknameView.swift
+//  MyPetFeature
+//
+//  Created by 조용인 on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import DesignKit
+import DotLottie
+
+public struct ChangeMyPetNicknameView: View {
+  @Bindable var store: StoreOf<ChangeMyPetNicknameFeature>
+  
+  public init(store: StoreOf<ChangeMyPetNicknameFeature>) {
+    self.store = store
+  }
+  
+  public var body: some View {
+    VStack(spacing: 0) {
+      NavigationBarView
+      VStack(alignment: .leading) {
+        CustomTextField(
+          placeholder: "",
+          text: $store.name,
+          state: .constant(store.textFieldState),
+          isFocused: $store.isFocused
+        ) {
+          Text(store.errorMessage)
+        }
+        .padding(.horizontal, .Number16)
+        .padding(.vertical, .Number24)
+        Spacer()
+      }
+      
+      PrimaryButton(
+        loadingView: {
+          DotLottieAnimation(
+            fileName: LottieSet.loading.name,
+            config: AnimationConfig(autoplay: true, loop: true)
+          ).view()
+        },
+        isLoading: $store.isLoading,
+        title: .constant("변경하기"),
+        size: .large,
+        state: $store.buttonState
+      ) {
+        store.send(.changeNicknameButtonTapped)
+      }
+      .padding(.Number16)
+    }
+    .background(ColorSet.Background.Primary)
+    .navigationBarBackButtonHidden(true)
+  }
+  
+  @ViewBuilder
+  private var NavigationBarView: some View {
+    NavigationBar(
+      backContent: {
+        TouchArea(image: .leftChevron) {
+          store.send(.backButtonTapped)
+        }
+      },
+      title: "펫 이름 변경"
+    )
+  }
+}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -37,6 +37,8 @@ public struct MyPetView: View {
       switch store.case {
       case let .petDetail(store):
         MyPetDetailView(store: store)
+      case let .changeNickname(store):
+        ChangeMyPetNicknameView(store: store)
       }
     }
     .onChange(of: store.path) { oldValue, newValue in

--- a/Projects/Sseudam/Sources/DependencyRegister.swift
+++ b/Projects/Sseudam/Sources/DependencyRegister.swift
@@ -157,12 +157,17 @@ struct DependencyRegister {
       FetchTrashSpotRawDetailUseCase.live(repository: trashSpotRepository)
     }
     
+    // MARK: - Pet
     CheckPetInfoUseCaseRegister {
       CheckPetInfoUseCase.live(repository: petRepository)
     }
     
     FetchPetSeasonInfoUseCaseRegister {
       FetchPetSeasonInfoUseCase.live(repository: petRepository)
+    }
+    
+    ChangePetNicknameUseCaseRegister {
+      ChangePetNicknameUseCase.live(repository: petRepository)
     }
     // MARK: - Visited
     


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #61 

## 🔎 작업 내용
- 마이펫의 닉네임을 변경하는 UI와 API 연동
- 우선, 마이펫 이름의 유효성 검사는 간소화하여 글자수 제한만 넣었습니다.
## 📷 스크린샷

https://github.com/user-attachments/assets/f160a48c-e760-4311-897a-9ae71c5062b2


## 🛠️ 기타 공유 내용
- 중간 작업 커밋을 깜빡해서, 그냥 한 번에 ㅎㅎ,,,


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced the ability to change your pet's nickname, including a dedicated screen for nickname updates with input validation and error handling.
  * Added a new button and navigation flow in the My Pet section to access the nickname change feature.
  * The nickname change screen provides real-time feedback, loading animations, and clear validation messages.

* **Enhancements**
  * Improved cache expiration settings for pet-related data to ensure more up-to-date information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->