### PR TITLE
출석 api 적용

### DIFF
--- a/Projects/Data/Attendance/AttendanceData/Sources/AttendanceRepositoryImpl.swift
+++ b/Projects/Data/Attendance/AttendanceData/Sources/AttendanceRepositoryImpl.swift
@@ -12,11 +12,12 @@ import AttendanceDataInterface
 import NetworkKit
 
 public extension AttendanceRepository {
-  static var live: AttendanceRepository {
+  static func live(networker: NetworkKit) -> AttendanceRepository {
     AttendanceRepository(
-      fetchData: {
-        // 실제 네트워크 작업 구현
-        return
+      checkAttendance: { userId in
+        let parameter = AttendanceBody(user: userId)
+        let endpoint = AttendanceEndPoint.checkAttendance(parameter: parameter)
+        return try await networker.execute(with: endpoint, timeout: 30).toEntity()
       }
     )
   }

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
@@ -21,7 +21,8 @@ public struct AttendanceDTO: DTO {
     .init(
       userId: userId,
       continuity: continuity,
-      isContinuity: isContinuity
+      isContinuity: isContinuity,
+      attendanceDate: createdAt.toDateFromISO8601
     )
   }
 }

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
@@ -21,17 +21,7 @@ public struct AttendanceDTO: DTO {
     .init(
       userId: userId,
       continuity: continuity,
-      isContinity: isContinuity
+      isContinuity: isContinuity
     )
   }
 }
-
-/*
- {
-   "userId": 1,
-   "date": "2025-06-30",
-   "continuity": 3,
-   "isContinuity": true,
-   "createdAt": "2025-06-30T12:00:00"
- }
- */

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
@@ -8,5 +8,30 @@
 
 import Foundation
 import AttendanceDomainInterface
+import NetworkKit
 
+public struct AttendanceDTO: DTO {
+  let userId: Int
+  let date: String
+  let continuity: Int
+  let isContinuity: Bool
+  let createdAt: String
+  
+  public func toEntity() throws -> AttendanceEntity {
+    .init(
+      userId: userId,
+      continuity: continuity,
+      isContinity: isContinuity
+    )
+  }
+}
 
+/*
+ {
+   "userId": 1,
+   "date": "2025-06-30",
+   "continuity": 3,
+   "isContinuity": true,
+   "createdAt": "2025-06-30T12:00:00"
+ }
+ */

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/DTO/AttendanceDTO.swift
@@ -18,11 +18,11 @@ public struct AttendanceDTO: DTO {
   let createdAt: String
   
   public func toEntity() throws -> AttendanceEntity {
-    .init(
+    return  .init(
       userId: userId,
       continuity: continuity,
       isContinuity: isContinuity,
-      attendanceDate: createdAt.toDateFromISO8601
+      attendanceDate: createdAt.toUTCDate
     )
   }
 }

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/EndPoint/AttendanceEndPoint.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/EndPoint/AttendanceEndPoint.swift
@@ -1,0 +1,24 @@
+//
+//  AttendanceEndPoint.swift
+//  AttendanceDataInterface
+//
+//  Created by Jiyeon on 7/25/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+import AttendanceDomainInterface
+import NetworkKit
+import UserDefaults
+
+public struct AttendanceEndPoint: Sendable {
+  public static func checkAttendance(parameter: AttendanceBody) -> Endpoint<AttendanceDTO> {
+    let accessToken = UserDefaultsKeys.accessToken
+    return Endpoint(
+      headers: .authorization(accessToken),
+      method: .post,
+      path: "/attendance",
+      parameters: .query(parameter)
+    )
+  }
+}

--- a/Projects/Data/Attendance/AttendanceDataInterface/Sources/Parameter/AttendanceBody.swift
+++ b/Projects/Data/Attendance/AttendanceDataInterface/Sources/Parameter/AttendanceBody.swift
@@ -1,0 +1,17 @@
+//
+//  AttendanceBody.swift
+//  AttendanceDataInterface
+//
+//  Created by Jiyeon on 7/25/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public struct AttendanceBody: Encodable {
+  let user: Int
+  
+  public init(user: Int) {
+    self.user = user
+  }
+}

--- a/Projects/Data/Visited/VisitedDataInterface/Sources/DTO/CheckRecentVisitDTO.swift
+++ b/Projects/Data/Visited/VisitedDataInterface/Sources/DTO/CheckRecentVisitDTO.swift
@@ -24,11 +24,11 @@ public struct CheckRecentVisitDTO: DTO {
   }
   
   public func toEntity() throws -> CheckRecentVisitEntity {
-    let lastVisitedAt: Date? = lastVisitedAt?.toDateFromISO8601
+    let lastVisitedAt: Date? = lastVisitedAt?.toKSTDate
     let expiredAt: Date? = lastVisitedAt?.addingTimeInterval(300)
     var isExpired: Bool = true
     if let expiredAt = expiredAt {
-      isExpired =  expiredAt.remainingFromNow() == nil
+      isExpired = expiredAt.remainingFromNow() == nil
     }
     return .init(expiredAt: expiredAt, isExpired: isExpired)
   }

--- a/Projects/Data/Visited/VisitedDataInterface/Sources/DTO/VisitedDTO.swift
+++ b/Projects/Data/Visited/VisitedDataInterface/Sources/DTO/VisitedDTO.swift
@@ -21,7 +21,7 @@ public struct VisitedDTO: DTO {
   
   public func toEntity() throws -> VisitedCompleteEntity {
     return .init(
-      visitedAt: visitedAt.toDateFromISO8601,
+      visitedAt: visitedAt.toKSTDate,
       isTodayFirst: isToday
     )
   }

--- a/Projects/Domain/Attendance/AttendanceDomain/Sources/AttendanceUseCaseImpl.swift
+++ b/Projects/Domain/Attendance/AttendanceDomain/Sources/AttendanceUseCaseImpl.swift
@@ -11,8 +11,8 @@ import AttendanceDomainInterface
 
 extension AttendanceUseCase {
   public static func live(repository: AttendanceRepository) -> AttendanceUseCase {
-    .init {
-      try await repository.fetchData()
+    .init { userId in
+      try await repository.checkAttendance(userId)
     }
   }
 }

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/AttendanceRepository.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/AttendanceRepository.swift
@@ -9,9 +9,11 @@
 import Foundation
 
 public struct AttendanceRepository {
-  public var fetchData: @Sendable () async throws -> Void
+  public var checkAttendance: @Sendable (_ userId: Int) async throws -> AttendanceEntity
 
-  public init(fetchData: @Sendable @escaping () async throws -> Void) {
-    self.fetchData = fetchData
+  public init(
+    checkAttendance: @Sendable @escaping (_ userId: Int) async throws -> AttendanceEntity
+  ) {
+    self.checkAttendance = checkAttendance
   }
 }

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
@@ -8,5 +8,14 @@
 
 import Foundation
 
-
-
+public struct AttendanceEntity: Sendable, Equatable {
+  public let userId: Int
+  public let continuity: Int
+  public let isContinity: Bool
+  
+  public init(userId: Int, continuity: Int, isContinity: Bool) {
+    self.userId = userId
+    self.continuity = continuity
+    self.isContinity = isContinity
+  }
+}

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
@@ -13,8 +13,9 @@ public struct AttendanceEntity: Sendable, Equatable {
   public let continuity: Int
   public let isContinuity: Bool
   public let status: AttendanceStatus
+  public let attendanceDate: Date?
   
-  public init(userId: Int, continuity: Int, isContinuity: Bool) {
+  public init(userId: Int, continuity: Int, isContinuity: Bool, attendanceDate: Date?) {
     self.userId = userId
     self.continuity = continuity
 
@@ -32,5 +33,6 @@ public struct AttendanceEntity: Sendable, Equatable {
     }
 
     self.status = status
+    self.attendanceDate = attendanceDate
   }
 }

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
@@ -11,11 +11,26 @@ import Foundation
 public struct AttendanceEntity: Sendable, Equatable {
   public let userId: Int
   public let continuity: Int
-  public let isContinity: Bool
+  public let isContinuity: Bool
+  public let status: AttendanceStatus
   
-  public init(userId: Int, continuity: Int, isContinity: Bool) {
+  public init(userId: Int, continuity: Int, isContinuity: Bool) {
     self.userId = userId
     self.continuity = continuity
-    self.isContinity = isContinity
+
+    let status: AttendanceStatus
+    switch continuity {
+    case 1:
+      self.isContinuity = true
+      status = .first
+    case 5:
+      self.isContinuity = isContinuity
+      status = .continuedSuccess
+    default:
+      self.isContinuity = isContinuity
+      status = isContinuity ? .success(day: continuity) : .fail
+    }
+
+    self.status = status
   }
 }

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceEntity.swift
@@ -24,9 +24,11 @@ public struct AttendanceEntity: Sendable, Equatable {
     case 1:
       self.isContinuity = true
       status = .first
+      
     case 5:
       self.isContinuity = isContinuity
       status = .continuedSuccess
+      
     default:
       self.isContinuity = isContinuity
       status = isContinuity ? .success(day: continuity) : .fail

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceStatus.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/Entity/AttendanceStatus.swift
@@ -1,0 +1,16 @@
+//
+//  AttendanceStatus.swift
+//  AttendanceDomainInterface
+//
+//  Created by Jiyeon on 7/27/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import Foundation
+
+public enum AttendanceStatus: Sendable, Equatable {
+  case first
+  case success(day: Int)
+  case fail
+  case continuedSuccess
+}

--- a/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/UseCases/AttendanceUseCase.swift
+++ b/Projects/Domain/Attendance/AttendanceDomainInterface/Sources/UseCases/AttendanceUseCase.swift
@@ -9,9 +9,9 @@
 import Foundation
 
 public struct AttendanceUseCase {
-  public var execute: @Sendable () async throws -> Void
+  public var execute: @Sendable (_ userId: Int) async throws -> AttendanceEntity
   
-  public init(execute: @Sendable @escaping () async throws -> Void) {
+  public init(execute: @Sendable @escaping (_ userId: Int) async throws -> AttendanceEntity) {
     self.execute = execute
   }
 }

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
@@ -22,10 +22,15 @@ public struct AttendanceFeature {
     public var continuityCount: Int
     public var isContinuity: Bool
     public var toastMessage: AttributedString? = nil
+    public var buttonTitle: String = "확인"
+    
     public init(_ data: AttendanceEntity) {
       continuityCount = data.continuity
       isContinuity = data.isContinuity
       attendanceStatus = data.status
+      if data.status == .fail {
+        buttonTitle = "다음"
+      }
     }
   }
 
@@ -34,6 +39,9 @@ public struct AttendanceFeature {
     case onAppear
     case showToastMessage(AttributedString?)
     case confirmButtonTapped
+    
+    case handleContinuityFail
+    case nextButtonTapped
     
     case dismiss
     case delegate(Delegate)
@@ -50,7 +58,10 @@ public struct AttendanceFeature {
     Reduce { state, action in
       switch action {
       case .onAppear:
-        return sseudamToast(continuityCnt: state.continuityCount)
+        if state.attendanceStatus != .fail {
+          return sseudamToast(continuityCnt: state.continuityCount)
+        }
+        return .none
         
       case let .showToastMessage(msg):
         state.toastMessage = msg
@@ -59,6 +70,13 @@ public struct AttendanceFeature {
       case .confirmButtonTapped:
         return .send(.dismiss)
         
+      case .handleContinuityFail:
+        state.buttonTitle = "확인"
+        state.attendanceStatus = .first
+        state.continuityCount = 1
+        state.isContinuity = true
+        return sseudamToast(continuityCnt: 1)
+        
       case .dismiss:
         return .send(.delegate(.dismiss))
         
@@ -66,7 +84,9 @@ public struct AttendanceFeature {
       }
     }
   }
-  
+}
+
+extension AttendanceFeature {
   private func sseudamToast(continuityCnt: Int) -> Effect<Action> {
     let point = continuityCnt == 5 ? "5쓰담" : "2쓰담"
     var attributed: AttributedString {

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
@@ -9,21 +9,24 @@
 import Foundation
 import ComposableArchitecture
 import DesignKit
+import AttendanceDomainInterface
 
 @Reducer
 public struct AttendanceFeature {
   
-  public init() {
-    
-  }
+  public init() { }
   
   @ObservableState
   public struct State: Equatable {
-    public var attendanceStatus: AttendanceStatus = .success(day: 3)
-    public var continuityCount: Int = 2
-    public var isContinuity: Bool = false
+    public var attendanceStatus: AttendanceStatus
+    public var continuityCount: Int
+    public var isContinuity: Bool
     public var toastMessage: AttributedString? = nil
-    public init() {}
+    public init(_ data: AttendanceEntity) {
+      continuityCount = data.continuity
+      isContinuity = data.isContinuity
+      attendanceStatus = data.status
+    }
   }
 
   public enum Action: BindableAction, Equatable {
@@ -39,6 +42,8 @@ public struct AttendanceFeature {
   public enum Delegate: Equatable {
     case dismiss
   }
+  
+  
 
   public var body: some ReducerOf<Self> {
     BindingReducer()

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceStatus.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceStatus.swift
@@ -7,13 +7,7 @@
 //
 
 import Foundation
-
-public enum AttendanceStatus: Equatable {
-  case first
-  case success(day: Int)
-  case fail
-  case continuedSuccess
-}
+import AttendanceDomainInterface
 
 extension AttendanceStatus {
   var description: String {

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceView.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceView.swift
@@ -25,10 +25,14 @@ public struct AttendanceView: View {
         pointView
         attendanceStateView
         PrimaryButton(
-          title: .constant("확인"),
+          title: $store.buttonTitle,
           state: .constant(.normal)
         ) {
-          store.send(.confirmButtonTapped)
+          if store.attendanceStatus == .fail {
+            store.send(.handleContinuityFail)
+          } else {
+            store.send(.confirmButtonTapped)
+          }
         }
         .padding(.Number16)
       }

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceView.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceView.swift
@@ -56,7 +56,10 @@ public struct AttendanceView: View {
             .font(FontSet.Body.body3)
             .foregroundStyle(ColorSet.Text.Secondary)
         }
-        AttendanceTrackerView(continuityCount: store.continuityCount, isContinuing: store.isContinuity)
+        AttendanceTrackerView(
+          continuityCount: store.continuityCount,
+          isContinuing: store.isContinuity
+        )
         Spacer()
       }
       VStack {
@@ -84,7 +87,7 @@ public struct AttendanceView: View {
       .multilineTextAlignment(.center)
       .font(FontSet.Heading.heading1)
     default:
-      Text(store.attendanceStatus.description)
+      Text(store.attendanceStatus.title)
         .multilineTextAlignment(.center)
         .font(FontSet.Heading.heading1)
         .foregroundStyle(ColorSet.Text.Primary)

--- a/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
@@ -21,4 +21,7 @@ public struct UserDefaultsKeys {
   @UserDefault("userId", default: nil)
   public static var userId: Int?
   
+  @UserDefault("lastEntryDate", default: nil)
+  public static var lastEntryDate: Date?
+  
 }

--- a/Projects/Shared/Utility/Sources/Extension/Date+.swift
+++ b/Projects/Shared/Utility/Sources/Extension/Date+.swift
@@ -26,4 +26,9 @@ extension Date {
       let interval = self.timeIntervalSinceNow
       return interval > 0 ? interval : nil
   }
+  
+  /// 타겟 날짜가 오늘 날짜인지 여부
+  public var isSameDayAsToday: Bool {
+    Calendar.current.isDateInToday(self)
+  }
 }

--- a/Projects/Shared/Utility/Sources/Extension/String+.swift
+++ b/Projects/Shared/Utility/Sources/Extension/String+.swift
@@ -42,7 +42,16 @@ extension String {
     return self.toFormattedDate(format) == self ? nil : self.toFormattedDate(format)
   }
   
-  public var toDateFromISO8601: Date? {
+  /// KST 기준 변환
+  public var toKSTDate: Date? {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
+    formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+    return formatter.date(from: self)
+  }
+
+  /// UTC 기준 변환
+  public var toUTCDate: Date? {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
     formatter.timeZone = TimeZone(secondsFromGMT: 0)

--- a/Projects/Shared/Utility/Sources/Extension/String+.swift
+++ b/Projects/Shared/Utility/Sources/Extension/String+.swift
@@ -45,7 +45,7 @@ extension String {
   public var toDateFromISO8601: Date? {
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSS"
-    formatter.timeZone = TimeZone(identifier: "Asia/Seoul")
+    formatter.timeZone = TimeZone(secondsFromGMT: 0)
     return formatter.date(from: self)
   }
   

--- a/Projects/Sseudam/Sources/DependencyRegister.swift
+++ b/Projects/Sseudam/Sources/DependencyRegister.swift
@@ -38,6 +38,10 @@ import VisitedDomainInterface
 import VisitedDomain
 import VisitedData
 
+import AttendanceDomainInterface
+import AttendanceDomain
+import AttendanceData
+
 import NetworkKit
 
 /// 비즈니스 로직의 의존성을 주입하기 위한 구조체
@@ -51,7 +55,7 @@ struct DependencyRegister {
     let reportRepository = ReportRepository.live(networker: networker)
     let petRepository = PetRepository.live(networker: networker)
     let visitedRepository = VisitedRepository.live(networker: networker)
-    
+    let attendanceRepository = AttendanceRepository.live(networker: networker)
     let nmGeometryRepository = NMReverseGeoCodeRepository.live
     let suggestionRepository = SpotSuggestionRepository.live
 
@@ -178,6 +182,11 @@ struct DependencyRegister {
     
     CheckRecentVisitUseCaseRegister {
       CheckRecentVisitUseCase.live(repository: visitedRepository)
+    }
+    
+    // MARK: - Attendance
+    AttendanceUseCaseRegister {
+      AttendanceUseCase.live(repository: attendanceRepository)
     }
   }
 }

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -33,6 +33,7 @@ struct UserEntryFeature {
     
     case checkAttendance
     case checkAttendanceResult(Result<AttendanceEntity, NetworkError>)
+    case saveAttendanceDate(Date)
     
     case modal(PresentationAction<Modal.Action>)
   }
@@ -58,13 +59,22 @@ struct UserEntryFeature {
         
         // MARK: - Attendance
       case .checkAttendance:
-        return checkAttendance(userId: state.userId)
+        if isFirstAppOpenToday() {
+          return checkAttendance(userId: state.userId)
+        } else {
+          return .send(.checkComplete)
+        }
         
       case let .checkAttendanceResult(.success(data)):
         state.modal = .attendance(AttendanceFeature.State(data))
+        return .send(.saveAttendanceDate(data.attendanceDate ?? Date()))
+        
+      case let .saveAttendanceDate(date):
+        UserDefaultsKeys.lastEntryDate = date
         return .none
         
       case let .checkAttendanceResult(.failure(error)):
+        print(error)
         return .send(.checkComplete)
         
       case let .modal(.presented(.attendance(action))):
@@ -75,12 +85,22 @@ struct UserEntryFeature {
         default: return .none
         }
         
-        
-        
       default: return .none
       }
     }
     .ifLet(\.$modal, action: \.modal)
+  }
+}
+
+extension UserEntryFeature {
+  /// 오늘 첫 진입 여부, 첫 진입 시 출석체크
+  private func isFirstAppOpenToday() -> Bool {
+    let lastDate = UserDefaultsKeys.lastEntryDate
+    
+    guard let lastDate = lastDate else {
+      return true
+    }
+    return !lastDate.isSameDayAsToday
   }
   
   private func checkAttendance(userId: Int) -> Effect<Action> {

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -1,0 +1,98 @@
+//
+//  UserEntryFeature.swift
+//  Sseudam
+//
+//  Created by Jiyeon on 7/26/25.
+//  Copyright © 2025 Sseudam.a2bo.ios. All rights reserved.
+//
+
+import SwiftUI
+import ComposableArchitecture
+import UserDefaults
+import Utility
+
+import AttendanceFeature
+import AttendanceDomainInterface
+
+@Reducer
+struct UserEntryFeature {
+  @ObservableState
+  struct State {
+    @Presents var modal: Modal.State?
+    var userId: Int
+    
+    init(userId: Int) {
+      self.userId = userId
+    }
+  }
+  
+  enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+    case delegate(Delegate)
+    case checkComplete
+    
+    case checkAttendance
+    case checkAttendanceResult(Result<AttendanceEntity, NetworkError>)
+    
+    case modal(PresentationAction<Modal.Action>)
+  }
+  
+  enum Delegate: Equatable {
+    case checkComplete
+  }
+  
+  @Reducer(state: .equatable, action: .equatable)
+  enum Modal {
+    case attendance(AttendanceFeature)
+  }
+  
+  @Dependency(\.AttendanceUseCase) var attendanceUseCase
+  
+  var body: some ReducerOf<Self> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+        
+      case .checkComplete:
+        return .send(.delegate(.checkComplete))
+        
+        // MARK: - Attendance
+      case .checkAttendance:
+        return checkAttendance(userId: state.userId)
+        
+      case let .checkAttendanceResult(.success(data)):
+        state.modal = .attendance(AttendanceFeature.State(data))
+        return .none
+        
+      case let .checkAttendanceResult(.failure(error)):
+        return .send(.checkComplete)
+        
+      case let .modal(.presented(.attendance(action))):
+        switch action {
+        case .delegate(.dismiss):
+          state.modal = nil
+          return .send(.checkComplete)
+        default: return .none
+        }
+        
+        
+        
+      default: return .none
+      }
+    }
+    .ifLet(\.$modal, action: \.modal)
+  }
+  
+  private func checkAttendance(userId: Int) -> Effect<Action> {
+    return .run { send in
+      do {
+        let result = try await attendanceUseCase.execute(userId)
+        await send(.checkAttendanceResult(.success(result)))
+      } catch let error as NetworkError {
+        await send(.checkAttendanceResult(.failure(error)))
+      } catch {
+        await send(.checkAttendanceResult(.failure(.customError(message: error.localizedDescription))))
+      }
+    }
+  }
+}

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -95,13 +95,12 @@ struct UserEntryFeature {
 extension UserEntryFeature {
   /// 오늘 첫 진입 여부, 첫 진입 시 출석체크
   private func isFirstAppOpenToday() -> Bool {
-    return true
-//    let lastDate = UserDefaultsKeys.lastEntryDate
-//    
-//    guard let lastDate = lastDate else {
-//      return true
-//    }
-//    return !lastDate.isSameDayAsToday
+    let lastDate = UserDefaultsKeys.lastEntryDate
+    
+    guard let lastDate = lastDate else {
+      return true
+    }
+    return !lastDate.isSameDayAsToday
   }
   
   private func checkAttendance(userId: Int) -> Effect<Action> {

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -95,12 +95,13 @@ struct UserEntryFeature {
 extension UserEntryFeature {
   /// 오늘 첫 진입 여부, 첫 진입 시 출석체크
   private func isFirstAppOpenToday() -> Bool {
-    let lastDate = UserDefaultsKeys.lastEntryDate
-    
-    guard let lastDate = lastDate else {
-      return true
-    }
-    return !lastDate.isSameDayAsToday
+    return true
+//    let lastDate = UserDefaultsKeys.lastEntryDate
+//    
+//    guard let lastDate = lastDate else {
+//      return true
+//    }
+//    return !lastDate.isSameDayAsToday
   }
   
   private func checkAttendance(userId: Int) -> Effect<Action> {

--- a/Projects/Sseudam/Sources/SseudamFeature.swift
+++ b/Projects/Sseudam/Sources/SseudamFeature.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import DesignKit
 import ComposableArchitecture
+import UserDefaults
 
 import HomeFeature
 import MyPetFeature
@@ -28,19 +29,21 @@ struct SseudamFeature {
     var myPetRoot: MyPetRootFeature.State = .init()
     var mypageRoot: MyPageRootFeature.State = .init()
     var authFlow: AuthFlowFeature.State? = nil
+    var userEntry: UserEntryFeature.State? = nil
     var presentAlert: AlertType? = nil
-    @Presents var modal: Modal.State?
   }
   
   enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
     case selectTab(TabBarItem)
     case onAppear
+    case checkUserEntryState(userId: Int)
     
     case homeRoot(HomeRootFeature.Action)
     case myPetRoot(MyPetRootFeature.Action)
     case mypageRoot(MyPageRootFeature.Action)
     case authFlow(AuthFlowFeature.Action)
+    case userEntry(UserEntryFeature.Action)
     
     case requestLogin(isPresent: Bool)
     
@@ -48,12 +51,6 @@ struct SseudamFeature {
     case acceptAlertAction
     case dismissAlert(Bool)
     
-    case modal(PresentationAction<Modal.Action>)
-  }
-  
-  @Reducer(state: .equatable, action: .equatable)
-  enum Modal {
-    case attendance(AttendanceFeature)
   }
   
   var body: some ReducerOf<Self> {
@@ -74,9 +71,11 @@ struct SseudamFeature {
         return .none
         
       case .onAppear:
-        // TODO: - 출석 api 연결
-//        state.modal = .attendance(AttendanceFeature.State())
-        return .none
+        return checkIsLoggedIn()
+        
+      case let .checkUserEntryState(userId):
+        state.userEntry = .init(userId: userId)
+        return .send(.userEntry(.checkAttendance))
         
       case let .homeRoot(.delegate(.presentAlert(type))):
         state.presentAlert = type
@@ -127,13 +126,12 @@ struct SseudamFeature {
         state.presentAlert = nil
         return .none
         
-        // MARK: - Attendance
-      case let .modal(.presented(.attendance(action))):
+        // MARK: - UserEntry
+      case let .userEntry(.delegate(action)):
         switch action {
-        case .delegate(.dismiss):
-          state.modal = nil
+        case .checkComplete:
+          state.userEntry = nil
           return .none
-        default: return .none
         }
         
       default: return .none
@@ -142,12 +140,22 @@ struct SseudamFeature {
     .ifLet(\.authFlow, action: \.authFlow) {
       AuthFlowFeature()
     }
-    .ifLet(\.$modal, action: \.modal)
+    .ifLet(\.userEntry, action: \.userEntry) {
+      UserEntryFeature()
+    }
   }
   
 }
 
 extension SseudamFeature {
+  
+  private func checkIsLoggedIn() -> Effect<Action> {
+    if UserDefaultsKeys.isLoggedIn ?? false ,
+       let userId = UserDefaultsKeys.userId {
+      return .send(.checkUserEntryState(userId: userId))
+    }
+    return .none
+  }
 
   private func alertEffect(
     for type: AlertType,

--- a/Projects/Sseudam/Sources/SseudamFeature.swift
+++ b/Projects/Sseudam/Sources/SseudamFeature.swift
@@ -102,11 +102,12 @@ struct SseudamFeature {
         return .none
         
       case .authFlow(.delegate(.changeLoginState)):
-        return .run { send in
-          await send(.mypageRoot(.checkLoggedin))
-          await send(.myPetRoot(.checkLoggedin))
-          await send(.homeRoot(.checkLoggedin))
-        }
+        return .merge(
+          checkIsLoggedIn(),
+          .send(.mypageRoot(.checkLoggedin)),
+          .send(.myPetRoot(.checkLoggedin)),
+          .send(.homeRoot(.checkLoggedin))
+        )
         
       case let .requestLogin(isPresent):
         state.authFlow = isPresent ? .init() : nil

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -77,7 +77,7 @@ struct SseudamView: View {
     .fullScreenCover(item: $store.scope(state: \.authFlow?.modal?.complete, action: \.authFlow.modal.complete)) { store in
       SignUpCompleteView(store: store)
     }
-    .fullScreenCover(item: $store.scope(state: \.modal?.attendance, action: \.modal.attendance)) { store in
+    .fullScreenCover(item: $store.scope(state: \.userEntry?.modal?.attendance, action: \.userEntry.modal.attendance)) { store in
       AttendanceView(store: store)
     }
     .transaction { transaction in

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -38,31 +38,8 @@ struct SseudamView: View {
         MyPageRootView(store: store.scope(state: \.mypageRoot, action: \.mypageRoot))
           .tag(TabBarItem.myPage)
       }
-      VStack {
-        Spacer()
-        if !store.isTabbarHidden {
-          CustomTabBar(selectedTab: $store.selectedTab) {
-            store.send(.selectTab($0))
-          }
-          
-        }
-      }
-      if let alert =  store.presentAlert {
-        Alert(
-          type: alert,
-          isErrorType: alert.isErrorType,
-          closeAction: {
-            Task { @MainActor in
-              store.send(.closeAlertAction)
-            }
-          },
-          acceptAction: {
-            Task { @MainActor in
-              store.send(.acceptAlertAction)
-            }
-          }
-        )
-      }
+      TabBar
+      AlertView
     }
     .onAppear {
       store.send(.onAppear)
@@ -82,6 +59,39 @@ struct SseudamView: View {
     }
     .transaction { transaction in
       transaction.disablesAnimations = true
+    }
+  }
+  
+  @ViewBuilder
+  var TabBar: some View {
+    VStack {
+      Spacer()
+      if !store.isTabbarHidden {
+        CustomTabBar(selectedTab: $store.selectedTab) {
+          store.send(.selectTab($0))
+        }
+        
+      }
+    }
+  }
+  
+  @ViewBuilder
+  var AlertView: some View {
+    if let alert =  store.presentAlert {
+      Alert(
+        type: alert,
+        isErrorType: alert.isErrorType,
+        closeAction: {
+          Task { @MainActor in
+            store.send(.closeAlertAction)
+          }
+        },
+        acceptAction: {
+          Task { @MainActor in
+            store.send(.acceptAlertAction)
+          }
+        }
+      )
     }
   }
   


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #59 

## 🔎 작업 내용
- 출석 api 추가
- UserEntryFeature 추가
  - 앱 진입 시 체크하는 로직을 분리하기 위해 UserEntryFeature를 SseudamFeature의 하위 feature로 생성
- 앱 진입 시 오늘 첫 진입인지 여부 확인
- 로그인 후 출석체크 여부 로직 연결
- 연속 출석 실패 플로우 추가

## 📷 스크린샷
연속 출석 실패 시 화면

https://github.com/user-attachments/assets/eff8f3e1-1a52-41b5-9018-6046fd7aafaa


## 🛠️ 기타 공유 내용
- 앱 진입 시 로그인이 되어있는 경우 또는 로그인 후 출석체크를 비롯해 제보 여부나 등등 체크해야하는 로직들이 들어갈 것 같아서, UserEntryFeature로 SseudamFeature의 하위 리듀서로 만들어뒀습니다!
- 출석 관련 애니메이션이 아직 정의되지 않아서 추후 프로토타입 나오면 적용할게용



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced user-specific attendance tracking with detailed status and continuity.
  * Added a user entry flow that checks attendance on first app open of the day and presents attendance info.
  * Enabled saving and verifying last entry date for daily attendance tracking.

* **Improvements**
  * Enhanced attendance UI with dynamic button titles and context-sensitive actions.
  * Updated date parsing to handle Korea Standard Time and UTC correctly.
  * Defined a comprehensive attendance status enum and entity for clearer status representation.
  * Refined state management and modal presentation for smoother user experience.

* **Bug Fixes**
  * Fixed date parsing issues in visited and attendance features to improve timezone accuracy.

* **Chores**
  * Registered attendance domain dependencies in the app’s dependency injection system.
  * Restructured main app feature to replace modal attendance flow with user entry feature integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->