### PR TITLE
쓰레기통 방문 인증 화면 레벨 바 추가 

### DIFF
--- a/Projects/Core/NetworkKit/Sources/Implementation/Interceptor.swift
+++ b/Projects/Core/NetworkKit/Sources/Implementation/Interceptor.swift
@@ -14,8 +14,11 @@ import Utility
 public struct Interceptor: TokenRefresher {
   
   public static func refreshToken() async throws -> String? {
+    print(#function)
     if let refreshToken: String = KeyChainService.read(forKey: .refreshToken) {
       let accessToken = UserDefaultsKeys.accessToken
+      print(accessToken)
+      print(refreshToken)
       let refreshEndpoint = Endpoint<TokenRefreshDTO>(
         headers: .authorization(accessToken),
         method: .post,

--- a/Projects/Core/NetworkKit/Sources/Implementation/Interceptor.swift
+++ b/Projects/Core/NetworkKit/Sources/Implementation/Interceptor.swift
@@ -15,8 +15,9 @@ public struct Interceptor: TokenRefresher {
   
   public static func refreshToken() async throws -> String? {
     if let refreshToken: String = KeyChainService.read(forKey: .refreshToken) {
+      let accessToken = UserDefaultsKeys.accessToken
       let refreshEndpoint = Endpoint<TokenRefreshDTO>(
-        headers: .plain,
+        headers: .authorization(accessToken),
         method: .post,
         path: "/auth/reissue",
         parameters: .body(ReissueTokenBody(refreshToken: refreshToken)),

--- a/Projects/Core/NetworkKit/Sources/Implementation/NetworkKit.swift
+++ b/Projects/Core/NetworkKit/Sources/Implementation/NetworkKit.swift
@@ -65,6 +65,7 @@ public struct NetworkKit: NetworkKitProtocol, Sendable {
       group.addTask { // 실제 네트워크 통신 Task
         let request = try endpoint.toURLRequest()
         let (data, response) = try await self.session.data(for: request)
+        dump(endpoint)
         return try await self.handleResponse(data: data, response: response, endpoint: endpoint)
       }
       group.addTask { // 타임아웃 체크 전용 Task

--- a/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
+++ b/Projects/Feature/Attendance/AttendanceFeature/Sources/AttendanceFeature.swift
@@ -41,7 +41,7 @@ public struct AttendanceFeature {
       continuityCount = data.continuity
       isContinuity = data.isContinuity
       attendanceStatus = data.status
-      sseudamPoint = data.continuity == 5 ? .continutityAttendance : .attendance
+      sseudamPoint = data.continuity == 5 ? .continuityAttendance : .attendance
       self.petInfo = petInfo
     }
   }

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
@@ -10,6 +10,8 @@ import Foundation
 import ComposableArchitecture
 import TrashSpotDomainInterface
 import ImageDownloadDomainInterface
+import PetDomainInterface
+
 import Utility
 import UserDefaults
 import DesignKit
@@ -55,7 +57,7 @@ public struct TrashDetailFeature {
     
     case showToastMessage(String?)
     case showAlert(AlertType)
-    case visitedComplete(isFirst: Bool)
+    case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
   }
   
   public enum Delegate: Equatable {
@@ -63,7 +65,7 @@ public struct TrashDetailFeature {
     case showToastMessage(String?)
     case showAlert(AlertType)
     /// 방문 완료
-    case visitedComplete(isFirst: Bool)
+    case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
   }
   
   @Dependency(\.FetchTrashSpotDetailUseCase) var fetchTrashSpotDetailUseCase
@@ -145,8 +147,8 @@ public struct TrashDetailFeature {
         return checkLoginState()
         
         // MARK: - Send Delegate To Parent Feature
-      case let .visitedComplete(isFirst):
-        return .send(.delegate(.visitedComplete(isFirst: isFirst)))
+      case let .visitedComplete(isFirst, petInfo):
+        return .send(.delegate(.visitedComplete(isFirst: isFirst, petInfo: petInfo)))
         
       case let .showToastMessage(message):
         return .send(.delegate(.showToastMessage(message)))
@@ -157,8 +159,8 @@ public struct TrashDetailFeature {
         // MARK: - Receive VisitedFeature Delegate Action
       case let .visited(.delegate(action)):
         switch action {
-        case let .visitedComplete(isFirst):
-          return .send(.visitedComplete(isFirst: isFirst))
+        case let .visitedComplete(isFirst, petInfo):
+          return .send(.visitedComplete(isFirst: isFirst, petInfo: petInfo))
           
         case let .showToastMessage(message):
           return .send(.showToastMessage(message))

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
@@ -149,14 +149,12 @@ public struct VisitedFeature {
         )
         
       case .visitButtonTapped:
-        let test: PetInfoEntity = .init(nickname: "", point: 10, levelType: "LEVEL_1", maxLevelStandard: 20)
-        return .send(.visitedComplete(isFirst: true, petInfo: test))
-//        guard state.visitedState == .enableVisit else {
-//          return .send(.disableVisit)
-//        }
-//        
-//        state.visitedState = .notDetermine
-//        return .send(.fetchPetInfo)
+        guard state.visitedState == .enableVisit else {
+          return .send(.disableVisit)
+        }
+        
+        state.visitedState = .notDetermine
+        return .send(.fetchPetInfo)
         
       case let .requestVisitResult(.success(result)):
         return .merge([

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
@@ -152,9 +152,10 @@ public struct VisitedFeature {
         guard state.visitedState == .enableVisit else {
           return .send(.disableVisit)
         }
-        
-        state.visitedState = .notDetermine
-        return .send(.fetchPetInfo)
+        return .merge([
+          .send(.changeVisitedState(.notDetermine)),
+          .send(.fetchPetInfo)
+        ])
         
       case let .requestVisitResult(.success(result)):
         return .merge([

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
@@ -149,12 +149,14 @@ public struct VisitedFeature {
         )
         
       case .visitButtonTapped:
-        guard state.visitedState == .enableVisit else {
-          return .send(.disableVisit)
-        }
-        
-        state.visitedState = .notDetermine
-        return .send(.fetchPetInfo)
+        let test: PetInfoEntity = .init(nickname: "", point: 10, levelType: "LEVEL_1", maxLevelStandard: 20)
+        return .send(.visitedComplete(isFirst: true, petInfo: test))
+//        guard state.visitedState == .enableVisit else {
+//          return .send(.disableVisit)
+//        }
+//        
+//        state.visitedState = .notDetermine
+//        return .send(.fetchPetInfo)
         
       case let .requestVisitResult(.success(result)):
         return .merge([

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
@@ -12,6 +12,7 @@ import Utility
 import DesignKit
 import UserDefaults
 import VisitedDomainInterface
+import PetDomainInterface
 
 @Reducer
 public struct VisitedFeature {
@@ -35,6 +36,8 @@ public struct VisitedFeature {
     public var isWithinDistance: Bool = false // 5m 범위 내에 있는지
     
     public var checkComplete: Bool = false
+    
+    var petInfo: PetInfoEntity? = nil
     
     public var timer: TimerFeature.State = .init()
   }
@@ -75,9 +78,12 @@ public struct VisitedFeature {
     /// 데이터 조회, 최근 인증 여부 조회 완료
     case checkComplete
     
+    case fetchPetInfo
+    case fetchPetInfoResult(Result<PetInfoEntity, NetworkError>)
+    
     // MARK: - Delegate
     
-    case visitedComplete(isFirst: Bool)
+    case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
     case showToastMessage(String?)
     case showAlert(AlertType)
     case delegate(Delegate)
@@ -86,13 +92,14 @@ public struct VisitedFeature {
   }
   
   public enum Delegate: Equatable {
-    case visitedComplete(isFirst: Bool)
+    case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
     case showToastMessage(String?)
     case showAlert(AlertType)
   }
   
   @Dependency(\.VisitedUseCase) var visitedUseCase
   @Dependency(\.CheckRecentVisitUseCase) var checkRecentVisitUseCase
+  @Dependency(\.CheckPetInfoUseCase) var checkPetInfoUseCase
   
   public var body: some ReducerOf<Self> {
     Scope(state: \.timer, action: \.timer) {
@@ -145,15 +152,13 @@ public struct VisitedFeature {
         guard state.visitedState == .enableVisit else {
           return .send(.disableVisit)
         }
-        guard let spotId = state.trashSpotId else {
-          return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
-        }
+        
         state.visitedState = .notDetermine
-        return requestVisited(spotId: spotId)
+        return .send(.fetchPetInfo)
         
       case let .requestVisitResult(.success(result)):
         return .merge([
-          .send(.visitedComplete(isFirst: result.isTodayFirst)),
+          .send(.visitedComplete(isFirst: result.isTodayFirst, petInfo: state.petInfo)),
           .send(.successVisit(date: result.visitedAt))
         ])
         
@@ -204,14 +209,30 @@ public struct VisitedFeature {
         state.checkComplete = true
         return .none
         
+      case .fetchPetInfo:
+        return fetchPetInfo()
+        
+      case let .fetchPetInfoResult(.success(entity)):
+        state.petInfo = entity
+        guard let spotId = state.trashSpotId else {
+          return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
+        }
+        return requestVisited(spotId: spotId)
+        
+      case let .fetchPetInfoResult(.failure(error)):
+        guard let spotId = state.trashSpotId else {
+          return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
+        }
+        return requestVisited(spotId: spotId)
+        
       case let .showToastMessage(message):
         return .send(.delegate(.showToastMessage(message)))
       
       case let .showAlert(type):
         return .send(.delegate(.showAlert(type)))
         
-      case let .visitedComplete(isFirst):
-        return .send(.delegate(.visitedComplete(isFirst: isFirst)))
+      case let .visitedComplete(isFirst, petInfo):
+        return .send(.delegate(.visitedComplete(isFirst: isFirst, petInfo: petInfo)))
         
         // MARK: - Timer
         
@@ -234,6 +255,19 @@ public struct VisitedFeature {
 }
 
 extension VisitedFeature {
+  
+  private func fetchPetInfo() -> Effect<Action> {
+    return .run { send in
+      do {
+        let data = try await checkPetInfoUseCase.execute()
+        await send(.fetchPetInfoResult(.success(data)))
+      } catch let error as NetworkError {
+        await send(.fetchPetInfoResult(.failure(error)))
+      } catch {
+        await send(.fetchPetInfoResult(.failure(.customError(message: error.localizedDescription))))
+      }
+    }
+  }
   
   /// 방문 처리
   private func requestVisited(spotId: Int) -> Effect<Action> {

--- a/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
+++ b/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
@@ -11,6 +11,7 @@ import ComposableArchitecture
 import DesignKit
 import DotLottie
 import PetDomainInterface
+import Utility
 
 @Reducer
 public struct VisitedCompleteFeature {
@@ -22,7 +23,7 @@ public struct VisitedCompleteFeature {
     
     var isFirstVisit: Bool
     var toastMessage: AttributedString? = nil
-    var sseudamCount: String
+    var sseudamPoint: SseudamPoint
     var animationState: AnimationState = .init()
     var isShowConfetti: Bool = false
     var isShowFirstVisitMessage: Bool = false
@@ -31,7 +32,7 @@ public struct VisitedCompleteFeature {
     
     public init(isFirstVisit: Bool, petInfo: PetInfoEntity?) {
       self.isFirstVisit = isFirstVisit
-      sseudamCount = isFirstVisit ? "7쓰담" : "5쓰담"
+      sseudamPoint = isFirstVisit ? .firstVisit : .visit
       self.petInfo = petInfo
     }
   }
@@ -41,7 +42,7 @@ public struct VisitedCompleteFeature {
     case onAppear
     case startAnimation
     case comfirmButtonTapped
-    case showToastMessage
+    case showToastMessage(AttributedString?)
     case resetToastMessage
     case animation(VisitedAnimationAction)
     case delegate(Delegate)
@@ -65,16 +66,8 @@ public struct VisitedCompleteFeature {
       case .comfirmButtonTapped:
         return .send(.delegate(.dismiss))
         
-      case .showToastMessage:
-        var attributed: AttributedString {
-          var sseudam = AttributedString(state.sseudamCount)
-          var text = AttributedString("이 적립됐어요!")
-          sseudam.foregroundColor = ColorSet.Text.InverseAccent
-          text.foregroundColor = ColorSet.Text.Inverse
-          sseudam.append(text)
-          return sseudam
-        }
-        state.toastMessage = attributed
+      case let .showToastMessage(message):
+        state.toastMessage = message
         return .none
         
       case .resetToastMessage:
@@ -103,7 +96,7 @@ public struct VisitedCompleteFeature {
           return .none
           
         case .showToastMessage:
-          return .send(.showToastMessage)
+          return sseudamToast(sseudam: state.sseudamPoint)
           
         case .levelBar:
           return .none
@@ -117,6 +110,20 @@ public struct VisitedCompleteFeature {
 }
 
 extension VisitedCompleteFeature {
+  
+  private func sseudamToast(sseudam: SseudamPoint) -> Effect<Action> {
+    let point = sseudam.sseudamText
+    var attributed: AttributedString {
+      var sseudam = AttributedString(point)
+      var text = AttributedString("이 적립됐어요!")
+      sseudam.foregroundColor = ColorSet.Text.InverseAccent
+      text.foregroundColor = ColorSet.Text.Inverse
+      sseudam.append(text)
+      return sseudam
+    }
+    return .send(.showToastMessage(attributed))
+  }
+  
   private func startAnimation(isFirstVisit: Bool) -> Effect<Action> {
     return .run { send in
       await send(.animation(.success))

--- a/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
+++ b/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
@@ -10,6 +10,7 @@ import Foundation
 import ComposableArchitecture
 import DesignKit
 import DotLottie
+import PetDomainInterface
 
 @Reducer
 public struct VisitedCompleteFeature {
@@ -26,10 +27,12 @@ public struct VisitedCompleteFeature {
     var isShowConfetti: Bool = false
     var isShowFirstVisitMessage: Bool = false
     var isShowButton: Bool = false
+    var petInfo: PetInfoEntity? = nil
     
-    public init(isFirstVisit: Bool) {
+    public init(isFirstVisit: Bool, petInfo: PetInfoEntity?) {
       self.isFirstVisit = isFirstVisit
       sseudamCount = isFirstVisit ? "7쓰담" : "5쓰담"
+      self.petInfo = petInfo
     }
   }
 

--- a/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
+++ b/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
@@ -29,6 +29,8 @@ public struct VisitedCompleteFeature {
     var isShowFirstVisitMessage: Bool = false
     var isShowButton: Bool = false
     var petInfo: PetInfoEntity? = nil
+    var showLevelBar: Bool = false
+    var startLevelAnimation: Bool = false
     
     public init(isFirstVisit: Bool, petInfo: PetInfoEntity?) {
       self.isFirstVisit = isFirstVisit
@@ -98,7 +100,12 @@ public struct VisitedCompleteFeature {
         case .showToastMessage:
           return sseudamToast(sseudam: state.sseudamPoint)
           
+        case .showLevelBar:
+          state.showLevelBar = true
+          return .none
+          
         case .levelBar:
+          state.startLevelAnimation = true
           return .none
         }
         
@@ -137,9 +144,13 @@ extension VisitedCompleteFeature {
       }
       try await Task.sleep(for: .seconds(0.8))
       await send(.animation(.showButton))
+      await send(.animation(.showLevelBar))
       
       try await Task.sleep(for: .seconds(0.4))
       await send(.animation(.showToastMessage))
+      
+      try await Task.sleep(for: .seconds(0.4))
+      await send(.animation(.levelBar))
     }
     
   }
@@ -153,6 +164,7 @@ extension VisitedCompleteFeature {
     case firstVisit
     case showButton
     case showToastMessage
+    case showLevelBar
     case levelBar
   }
   

--- a/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
+++ b/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteFeature.swift
@@ -40,13 +40,10 @@ public struct VisitedCompleteFeature {
     case binding(BindingAction<State>)
     case onAppear
     case startAnimation
-    case startSuccess
-    case startConfetti
-    case showFirstVisitText
-    case showButton
     case comfirmButtonTapped
     case showToastMessage
     case resetToastMessage
+    case animation(VisitedAnimationAction)
     case delegate(Delegate)
   }
   
@@ -64,26 +61,7 @@ public struct VisitedCompleteFeature {
         
       case .startAnimation:
         return startAnimation(isFirstVisit: state.isFirstVisit)
-        
-      case .startSuccess:
-        let duration = state.animationState.success.duration()
-        state.animationState.success.setSpeed(speed: duration / 1.0)
-        state.animationState.success.play()
-        return .none
-        
-      case .startConfetti:
-        state.isShowConfetti = true
-        state.animationState.confetti.play()
-        return .none
-        
-      case .showFirstVisitText:
-        state.isShowFirstVisitMessage = true
-        return .none
-        
-      case .showButton:
-        state.isShowButton = true
-        return .none
-        
+      
       case .comfirmButtonTapped:
         return .send(.delegate(.dismiss))
         
@@ -103,30 +81,73 @@ public struct VisitedCompleteFeature {
         state.toastMessage = nil
         return .none
         
+      case let .animation(animation):
+        switch animation {
+        case .success:
+          let duration = state.animationState.success.duration()
+          state.animationState.success.setSpeed(speed: duration / 1.0)
+          state.animationState.success.play()
+          return .none
+          
+        case .confetti:
+          state.isShowConfetti = true
+          state.animationState.confetti.play()
+          return .none
+          
+        case .firstVisit:
+          state.isShowFirstVisitMessage = true
+          return .none
+          
+        case .showButton:
+          state.isShowButton = true
+          return .none
+          
+        case .showToastMessage:
+          return .send(.showToastMessage)
+          
+        case .levelBar:
+          return .none
+        }
+        
+        
         default: return .none
       }
     }
   }
-  
+}
+
+extension VisitedCompleteFeature {
   private func startAnimation(isFirstVisit: Bool) -> Effect<Action> {
     return .run { send in
-      await send(.startSuccess)
-      try await Task.sleep(nanoseconds: 400_000_000)
-      await send(.startConfetti)
+      await send(.animation(.success))
+      
+      try await Task.sleep(for: .seconds(0.4))
+      await send(.animation(.confetti))
+      
       if isFirstVisit {
-        try await Task.sleep(nanoseconds: 800_000_000)
-        await send(.showFirstVisitText)
+        try await Task.sleep(for: .seconds(0.8))
+        await send(.animation(.firstVisit))
       }
-      try await Task.sleep(nanoseconds: 800_000_000)
-      await send(.showButton)
-      try await Task.sleep(nanoseconds: 400_000_000)
-      await send(.showToastMessage)
+      try await Task.sleep(for: .seconds(0.8))
+      await send(.animation(.showButton))
+      
+      try await Task.sleep(for: .seconds(0.4))
+      await send(.animation(.showToastMessage))
     }
     
   }
 }
 
 extension VisitedCompleteFeature {
+  
+  public enum VisitedAnimationAction: Equatable {
+    case success
+    case confetti
+    case firstVisit
+    case showButton
+    case showToastMessage
+    case levelBar
+  }
   
   public struct AnimationState: Equatable {
     var confetti = DotLottieAnimation(

--- a/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteView.swift
+++ b/Projects/Feature/Visited/VisitedFeature/Sources/VisitedCompleteView.swift
@@ -22,6 +22,7 @@ public struct VisitedCompleteView: View {
   public var body: some View {
     ZStack(alignment: .top) {
       ColorSet.Background.Primary
+      pointView
       mainContentView
       bottomView
     }
@@ -41,6 +42,27 @@ public struct VisitedCompleteView: View {
       
     }
     .padding(.horizontal, .Number16)
+  }
+  
+  private var pointView: some View {
+    VStack {
+      HStack {
+        Spacer()
+        if let petInfo = store.petInfo {
+          LevelBar(
+            currentLevel: petInfo.levelType,
+            currentPoint: petInfo.currentPoint,
+            addPoint: store.sseudamPoint.point,
+            maxLevelPoint: petInfo.goalPoint,
+            startAnimation: $store.startLevelAnimation
+          )
+          .opacity(store.showLevelBar ? 1 : 0)
+          .animation(.easeIn(duration: 0.1), value: store.showLevelBar)
+        }
+      }
+      .padding(.top, .Number20)
+      Spacer()
+    }
   }
   
   @ViewBuilder

--- a/Projects/Shared/Utility/Sources/Type/SseudamPoint.swift
+++ b/Projects/Shared/Utility/Sources/Type/SseudamPoint.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 public enum SseudamPoint {
-  case continutityAttendance
+  case continuityAttendance
   case attendance
   case firstVisit
   case visit
@@ -20,7 +20,7 @@ extension SseudamPoint {
     switch self {
     case .firstVisit:
       return 7
-    case .continutityAttendance, .visit:
+    case .continuityAttendance, .visit:
       return 5
     case .attendance:
       return 2

--- a/Projects/Shared/Utility/Sources/Type/SseudamPoint.swift
+++ b/Projects/Shared/Utility/Sources/Type/SseudamPoint.swift
@@ -11,13 +11,16 @@ import Foundation
 public enum SseudamPoint {
   case continutityAttendance
   case attendance
-  
+  case firstVisit
+  case visit
 }
 
 extension SseudamPoint {
   public var point: Int {
     switch self {
-    case .continutityAttendance:
+    case .firstVisit:
+      return 7
+    case .continutityAttendance, .visit:
       return 5
     case .attendance:
       return 2

--- a/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
+++ b/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
@@ -13,6 +13,7 @@ import TrashDetailFeature
 import DesignKit
 import VisitedFeature
 import TrashSpotDomainInterface
+import PetDomainInterface
 
 @Reducer
 struct HomeRootFeature {
@@ -32,7 +33,7 @@ struct HomeRootFeature {
     case trashDetail(TrashDetailFeature.Action)
     
     case presentDetail(Bool, id: Int?)
-    case presentVisitedComplete(isFirst: Bool)
+    case presentVisitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
     
     case closeAlertAction(AlertType)
     case acceptAlertAction(AlertType)
@@ -64,7 +65,7 @@ struct HomeRootFeature {
     }
     Reduce { state, action in
       switch action {
-
+        
         // MARK: - Alert
         
       case .closeAlertAction:
@@ -91,8 +92,13 @@ struct HomeRootFeature {
         }
         return .none
         
-      case let .presentVisitedComplete(isFirst):
-        state.modal = .visitedComplete(VisitedCompleteFeature.State(isFirstVisit: isFirst))
+      case let .presentVisitedComplete(isFirst, petInfo):
+        state.modal = .visitedComplete(
+          VisitedCompleteFeature.State(
+            isFirstVisit: isFirst,
+            petInfo: petInfo
+          )
+        )
         return .none
         
       case .checkLoggedin:
@@ -143,8 +149,8 @@ struct HomeRootFeature {
         case let .showAlert(type):
           return .send(.presentAlert(type))
           
-        case let .visitedComplete(isFirst):
-          return .send(.presentVisitedComplete(isFirst: isFirst))
+        case let .visitedComplete(isFirst, petInfo):
+          return .send(.presentVisitedComplete(isFirst: isFirst, petInfo: petInfo))
           
         }
         


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #77 

## 🔎 작업 내용
- 방문 인증 화면 진입 전 pet info 조회
- 방문 인증 화면 레벨바 적용

## 📷 스크린샷
<img src = "https://github.com/user-attachments/assets/6f6de83f-acbe-40c5-8f77-d88a8c837618" width = "250">

## 🛠️ 기타 공유 내용



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visit completion now includes pet info and shows an animated level bar with point gains.
  * Unified visit success animation sequence (confetti, first-visit messaging, contextual toasts).

* **Updates**
  * Point rewards adjusted: first visit +7, regular visit +5, continuity attendance +5.

* **Bug Fixes**
  * More reliable session/token handling during refresh to reduce unexpected logouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->