### PR TITLE
디테일 바텀시트 텍스트 길이에 따른 높이 조절 구현

### DIFF
--- a/Projects/Core/DesignKit/Sources/Component/BottomSheet/BottomSheetView.swift
+++ b/Projects/Core/DesignKit/Sources/Component/BottomSheet/BottomSheetView.swift
@@ -58,8 +58,8 @@ public struct BottomSheetOverlay<BottomSheetContent: View>: ViewModifier {
       .overlay(alignment: .bottom) {
         if showSheet {
           bottomSheetContent()
-            .padding(.bottom, .Number20)
             .frame(height: height)
+            .padding(.bottom, .Number10)
             .frame(maxWidth: .infinity)
             .background(.white)
             .clipCorners(.Number16, corners: [.topLeft, .topRight])

--- a/Projects/Core/DesignKit/Sources/Component/IconButton/IconButton.swift
+++ b/Projects/Core/DesignKit/Sources/Component/IconButton/IconButton.swift
@@ -31,17 +31,20 @@ public struct IconButton: View {
   public var icon: ImageSet
   public var action: () async -> Void
   private let type: ColorType
+  private let size: CGFloat
   
   @State private var isPressed: Bool = false
   
   public init(
     icon: ImageSet,
     type: ColorType = .primary,
+    size: CGFloat? = nil,
     _ action: @escaping () async -> Void
   ) {
     self.icon = icon
     self.action = action
     self.type = type
+    self.size = size ?? .Number48
   }
   
   public var body: some View {
@@ -80,6 +83,6 @@ public struct IconButton: View {
             .fill(ColorSet.Component.Pressed)
         }
       }
-      .frame(width: .Number48, height: .Number48)
+      .frame(width: size, height: size)
   }
 }

--- a/Projects/Core/DesignKit/Sources/Modifier/FontStyle.swift
+++ b/Projects/Core/DesignKit/Sources/Modifier/FontStyle.swift
@@ -14,7 +14,7 @@ private struct FontStyleModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       .font(font.font)
-      .lineSpacing(font.lineheight*0.7)
+      .lineSpacing(font.lineheight*0.6)
       .padding(.vertical, (font.lineheight / 2) * 0.6)
   }
 }

--- a/Projects/Core/DesignKit/Sources/Modifier/FontStyle.swift
+++ b/Projects/Core/DesignKit/Sources/Modifier/FontStyle.swift
@@ -14,7 +14,7 @@ private struct FontStyleModifier: ViewModifier {
   func body(content: Content) -> some View {
     content
       .font(font.font)
-      .lineSpacing(font.lineheight*0.6)
+      .lineSpacing(font.lineheight*0.7)
       .padding(.vertical, (font.lineheight / 2) * 0.6)
   }
 }

--- a/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
@@ -49,4 +49,5 @@ public extension CGFloat {
   static let Number320: CGFloat = 320
   
   static let detailSheetHeight: CGFloat = 197
+  static let detailSheetLargeHeight: CGFloat = 222
 }

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -33,6 +33,7 @@ public struct HomeFeature {
     public var isPresentDetail: Bool = false
     public var toastMessage: String? = nil
     public var isInitAppear: Bool = true
+    public var bottomSheetHeight: CGFloat = .detailSheetHeight
     public init() {}
   }
 
@@ -54,6 +55,7 @@ public struct HomeFeature {
     case moveToSuggestion
     case suggestionButtonTapped
     case delegate(Delegate)
+    case updateBottomSheetHeight(CGFloat)
   }
   
   public enum Delegate: Equatable {
@@ -176,6 +178,10 @@ public struct HomeFeature {
             await openURL(url)
           }
         }
+        
+      case let .updateBottomSheetHeight(height):
+        state.bottomSheetHeight = height + .Number10
+        return .none
         
       default: return .none
       }

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -91,7 +91,7 @@ public struct HomeView: View {
   private var TopButtonView: some View {
     HStack(spacing: .Number8) {
       if store.isPresentDetail {
-        IconButton(icon: .leftChevron) {
+        IconButton(icon: .leftChevron, size: .Number40) {
           store.send(.presentDetailView(false))
           store.send(.map(.deleteActiveMarker))
         }

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -22,7 +22,6 @@ public struct HomeView: View {
   }
   
   private let tabbarHeight: CGFloat = 83
-  private let bottomSheetHeight: CGFloat = .detailSheetHeight
   private let bottomPadding: CGFloat = .Number12
   
   public var body: some View {
@@ -126,7 +125,7 @@ public struct HomeView: View {
     .padding(.horizontal, .Number16)
     .padding(
       .bottom,
-      (store.isPresentDetail ? bottomSheetHeight : tabbarHeight)+bottomPadding
+      (store.isPresentDetail ? store.bottomSheetHeight : tabbarHeight)+bottomPadding
     )
     .animation(
       .easeInOut(duration: store.isPresentDetail ? 0.3 : 0.13),

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
@@ -30,6 +30,7 @@ public struct TrashDetailFeature {
     var isLoading: Bool = true
     var isFailLoadDetail: Bool = false
     var isNeedUpdateHeight: Bool = true
+    var isTitleMultiLine: Bool? = nil
     public var bottomSheetHeight: CGFloat = .detailSheetHeight
     public init() {}
   }
@@ -49,6 +50,7 @@ public struct TrashDetailFeature {
     case emptyTrashData(Bool)
     case fetchTrashDetail(id: Int)
     case fetchTrashDetailResult(Result<TrashSpotDetail, NetworkError>)
+    case setTitleMultiLine(Bool?)
     
     case fetchTrashImage(imgUrl: String?, id: Int)
     case fetchTrashImageResult(Result<Data, ImageDownloadError>)
@@ -91,6 +93,7 @@ public struct TrashDetailFeature {
             await send(.showLoading(true))
             await send(.emptyTrashData(false))
             await send(.setInitVisitedState)
+            await send(.setTitleMultiLine(nil))
             await send(.fetchTrashDetail(id: id))
           }
         } else {
@@ -138,6 +141,10 @@ public struct TrashDetailFeature {
           .send(.showLoading(false)),
           .send(.visited(.initialVisitedData))
         ])
+        
+      case let .setTitleMultiLine(isMultiLine):
+        state.isTitleMultiLine = isMultiLine
+        return .none
         
       case let .fetchTrashImage(imgUrl, id):
         guard let imgUrl = imgUrl else { return .none }

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
@@ -29,6 +29,7 @@ public struct TrashDetailFeature {
     var trashImageData: Data? = nil
     var isLoading: Bool = true
     var isFailLoadDetail: Bool = false
+    var isNeedUpdateHeight: Bool = true
     public var bottomSheetHeight: CGFloat = .detailSheetHeight
     public init() {}
   }
@@ -122,6 +123,7 @@ public struct TrashDetailFeature {
         
       case let .fetchTrashDetailResult(.success(data)):
         state.trashDetail = data
+        state.isNeedUpdateHeight = true
         return .merge([
           .send(.showLoading(false)),
           .send(.visited(.setTrashSpotInfo(spotId: data.id, point: data.point))),
@@ -167,6 +169,7 @@ public struct TrashDetailFeature {
         
       case let .updateBottomSheetHeight(height):
         state.bottomSheetHeight = height
+        state.isNeedUpdateHeight = false
         return .send(.delegate(.bottomSheetHeightChanged(height)))
         
         // MARK: - Receive VisitedFeature Delegate Action

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
@@ -29,6 +29,7 @@ public struct TrashDetailFeature {
     var trashImageData: Data? = nil
     var isLoading: Bool = true
     var isFailLoadDetail: Bool = false
+    public var bottomSheetHeight: CGFloat = .detailSheetHeight
     public init() {}
   }
 
@@ -59,6 +60,7 @@ public struct TrashDetailFeature {
     case showToastMessage(String?)
     case showAlert(AlertType)
     case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
+    case updateBottomSheetHeight(CGFloat)
   }
   
   public enum Delegate: Equatable {
@@ -67,6 +69,7 @@ public struct TrashDetailFeature {
     case showAlert(AlertType)
     /// 방문 완료
     case visitedComplete(isFirst: Bool, petInfo: PetInfoEntity?)
+    case bottomSheetHeightChanged(CGFloat)
   }
   
   @Dependency(\.FetchTrashSpotDetailUseCase) var fetchTrashSpotDetailUseCase
@@ -161,6 +164,10 @@ public struct TrashDetailFeature {
         
       case let .showAlert(type):
         return .send(.delegate(.showAlert(type)))
+        
+      case let .updateBottomSheetHeight(height):
+        state.bottomSheetHeight = height
+        return .send(.delegate(.bottomSheetHeightChanged(height)))
         
         // MARK: - Receive VisitedFeature Delegate Action
       case let .visited(.delegate(action)):

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
@@ -17,7 +17,6 @@ public struct TrashDetailView: View {
   @Bindable var store: StoreOf<TrashDetailFeature>
   @Environment(\.scenePhase) private var scenePhase
   @State private var downsampledImage: UIImage?
-  @State private var isNameMultiline: Bool? = nil
   
   public init(store: StoreOf<TrashDetailFeature>) {
     self.store = store
@@ -181,7 +180,7 @@ public struct TrashDetailView: View {
         .lineLimit(2)
         .foregroundStyle(ColorSet.Text.Primary)
         .background(calculateTruncation(text: name))
-        .fixedSize(horizontal: false, vertical: isNameMultiline ?? false)
+        .fixedSize(horizontal: false, vertical: store.isTitleMultiLine ?? false)
         .multilineTextAlignment(.leading)
       Text(address)
         .font(FontSet.Body.body3)
@@ -197,8 +196,7 @@ public struct TrashDetailView: View {
         .hidden()
         .onAppear {
           if store.isNeedUpdateHeight {
-            isNameMultiline = false
-            print("false")
+            store.send(.setTitleMultiLine(false))
             store.send(.updateBottomSheetHeight(.detailSheetHeight))
           }
         }
@@ -207,8 +205,7 @@ public struct TrashDetailView: View {
         .hidden()
         .onAppear {
           if store.isNeedUpdateHeight {
-            isNameMultiline = true
-            print("true")
+            store.send(.setTitleMultiLine(true))
             store.send(.updateBottomSheetHeight(.detailSheetLargeHeight))
           }
         }

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
@@ -17,6 +17,7 @@ public struct TrashDetailView: View {
   @Bindable var store: StoreOf<TrashDetailFeature>
   @Environment(\.scenePhase) private var scenePhase
   @State private var downsampledImage: UIImage?
+  @State private var isNameMultiline: Bool? = nil
   
   public init(store: StoreOf<TrashDetailFeature>) {
     self.store = store
@@ -52,7 +53,7 @@ public struct TrashDetailView: View {
   @ViewBuilder
   private func DetailContent(data: TrashSpotDetail) -> some View {
     VStack(spacing: .Number16) {
-      HStack(spacing: .Number16) {
+      HStack(alignment: .top, spacing: .Number16) {
         VStack(alignment: .leading, spacing: .Number8) {
           TrashLocationView(name: data.name, address: data.address)
           BadgesView(
@@ -62,16 +63,20 @@ public struct TrashDetailView: View {
           )
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        if data.isPublicData {
-          publicDataImageView
-        } else {
-          trashImageView
+        VStack {
+          if data.isPublicData {
+            publicDataImageView
+          } else {
+            trashImageView
+          }
+          Spacer()
         }
       }
       ButtonsView
+        .padding(.bottom, .Number20)
     }
     .padding(.horizontal, .Number16)
-    .padding(.vertical, .Number20)
+    .padding(.top, .Number20)
     .onAppear {
       LocationService.shared.startTracking()
     }
@@ -174,11 +179,37 @@ public struct TrashDetailView: View {
       Text(name)
         .font(FontSet.Heading.heading3)
         .foregroundStyle(ColorSet.Text.Primary)
+        .background(calculateTruncation(text: name))
+        .fixedSize(horizontal: false, vertical: isNameMultiline ?? false)
+        .multilineTextAlignment(.leading)
       Text(address)
         .font(FontSet.Body.body3)
         .foregroundStyle(ColorSet.Text.Primary)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
+  }
+  
+  private func calculateTruncation(text: String) -> some View {
+    ViewThatFits(in: .vertical) {
+      Text(text)
+        .font(FontSet.Heading.heading3)
+        .hidden()
+        .onAppear {
+          guard isNameMultiline == nil else { return }
+          isNameMultiline = false
+          print("false")
+          store.send(.updateBottomSheetHeight(.detailSheetHeight))
+        }
+      
+      Color.clear
+        .hidden()
+        .onAppear {
+          guard isNameMultiline == nil else { return }
+          isNameMultiline = true
+          print("true")
+          store.send(.updateBottomSheetHeight(.detailSheetLargeHeight))
+        }
+    }
   }
   
   @ViewBuilder
@@ -213,7 +244,6 @@ public struct TrashDetailView: View {
           size: .medium,
           state: $store.visited.visitedButtonState
         ) {
-          print(store.visited.visitedButtonState, store.visited)
           store.send(.visited(.visitButtonTapped))
         }
         .onTapGesture {
@@ -246,5 +276,3 @@ public struct TrashDetailView: View {
     }
   }
 }
-
-

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
@@ -178,6 +178,7 @@ public struct TrashDetailView: View {
     VStack(alignment: .leading, spacing: .Number4) {
       Text(name)
         .font(FontSet.Heading.heading3)
+        .lineLimit(2)
         .foregroundStyle(ColorSet.Text.Primary)
         .background(calculateTruncation(text: name))
         .fixedSize(horizontal: false, vertical: isNameMultiline ?? false)
@@ -195,19 +196,21 @@ public struct TrashDetailView: View {
         .font(FontSet.Heading.heading3)
         .hidden()
         .onAppear {
-          guard isNameMultiline == nil else { return }
-          isNameMultiline = false
-          print("false")
-          store.send(.updateBottomSheetHeight(.detailSheetHeight))
+          if store.isNeedUpdateHeight {
+            isNameMultiline = false
+            print("false")
+            store.send(.updateBottomSheetHeight(.detailSheetHeight))
+          }
         }
       
       Color.clear
         .hidden()
         .onAppear {
-          guard isNameMultiline == nil else { return }
-          isNameMultiline = true
-          print("true")
-          store.send(.updateBottomSheetHeight(.detailSheetLargeHeight))
+          if store.isNeedUpdateHeight {
+            isNameMultiline = true
+            print("true")
+            store.send(.updateBottomSheetHeight(.detailSheetLargeHeight))
+          }
         }
     }
   }

--- a/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
+++ b/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
@@ -24,6 +24,7 @@ struct HomeRootFeature {
     var trashDetail: TrashDetailFeature.State? = nil
     var isPresentDetail: Bool = false
     var tempSavingDetailData: TrashSpotDetail? = nil
+    var bottomSheetHeight: CGFloat = .detailSheetHeight
     @Presents var modal: ModalDestination.State?
   }
   
@@ -148,6 +149,10 @@ struct HomeRootFeature {
           
         case let .visitedComplete(isFirst, petInfo):
           return .send(.presentVisitedComplete(isFirst: isFirst, petInfo: petInfo))
+          
+        case let .bottomSheetHeightChanged(height):
+          state.bottomSheetHeight = height
+          return .send(.home(.updateBottomSheetHeight(height)))
           
         }
         

--- a/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootView.swift
+++ b/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootView.swift
@@ -22,7 +22,7 @@ struct HomeRootView: View {
   
   var body: some View {
     HomeView(store: store.scope(state: \.home, action: \.home))
-      .bottomSheet(isPresented: $store.isPresentDetail, height: .detailSheetHeight) {
+      .bottomSheet(isPresented: $store.isPresentDetail, height: store.bottomSheetHeight, maxHeight: .detailSheetLargeHeight) {
         IfLetStore(store.scope(state: \.trashDetail, action: \.trashDetail)) { store in
           TrashDetailView(store: store)
         }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- 쓰레기통 상세 정보의 타이틀 명이 2줄이 되는 경우를 감지하여 바텀시트 높이를 변경하도록 구현
- 아이콘 버튼의 크기 설정 가능하도록  프로퍼티 추가

## 📷 스크린샷

https://github.com/user-attachments/assets/e9ecc54d-02ff-4e0a-af98-816ec9af4cc2


## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Bottom sheet now adjusts its height dynamically based on content, with support for an expanded max height.
  - Icon buttons support a configurable size; the back button is now more compact.

- Style
  - Improved Trash Detail layout: top-aligned image, better title handling with multiline support and truncation awareness.
  - Adjusted paddings for bottom sheets and buttons for cleaner spacing.
  - Smoother bottom sheet presentation with refined bottom padding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->