### PR TITLE
Feature/#95 코치마크 추가

### DIFF
--- a/Projects/Core/DesignKit/Sources/Component/CoachMark/CoachMark.swift
+++ b/Projects/Core/DesignKit/Sources/Component/CoachMark/CoachMark.swift
@@ -12,44 +12,52 @@ import SwiftUI
 public enum CoachMarkPosition : Sendable {
   case top
   case bottom
-  case left
-  case right
 }
 
 public struct CoachMark: View {
   
+  @State private var isVisible: Bool = true
+  
   private var isSpring: Bool = false
   private var position: CoachMarkPosition = .bottom
+  private var offset: CGFloat = 0.0
   private var text: String
+  private var action: (() -> Void)? = nil
   
   public init(
-    text: String
+    text: String,
+    offset: CGFloat = 0.0,
+    action: (() -> Void)? = nil
   ) {
     self.text = text
+    self.offset = offset
+    self.action = action
   }
   
   public var body: some View {
-    
-    switch position {
-    case .top:
-      VStack(spacing: .Number0) {
-        TailingView.frame(width: .Number30, height: .Number8)
-        ContentView
-      }
-    case .bottom:
-      VStack(spacing: .Number0) {
-        ContentView
-        TailingView.frame(width: .Number30, height: .Number8)
-      }
-    case .left:
-      HStack(spacing: .Number0) {
-        TailingView.frame(width: .Number30, height: .Number8)
-        ContentView
-      }
-    case .right:
-      HStack(spacing: .Number0) {
-        ContentView
-        TailingView.frame(width: .Number30, height: .Number8)
+    if !isVisible { EmptyView() }
+    else {
+      switch position {
+      case .top:
+        VStack(spacing: .Number0) {
+          TailingView.frame(width: .Number36, height: .Number10)
+            .padding(.leading, offset)
+          ContentView
+        }
+        .onTapGesture {
+          isVisible = false
+          action?()
+        }
+      case .bottom:
+        VStack(spacing: .Number0) {
+          ContentView
+          TailingView.frame(width: .Number36, height: .Number10)
+            .padding(.leading, offset)
+        }
+        .onTapGesture {
+          isVisible = false
+          action?()
+        }
       }
     }
   }
@@ -57,7 +65,8 @@ public struct CoachMark: View {
   public var ContentView: some View {
     Group {
       Text(text)
-        .font(FontSet.Caption.caption2)
+        .multilineTextAlignment(.center)
+        .font(FontSet.Body.body3)
         .foregroundColor(ColorSet.Text.Inverse)
         .padding(.horizontal, .Number10)
         .padding(.vertical, .Number6)
@@ -81,50 +90,41 @@ public struct CoachMarkTail: Shape {
     
     switch position {
     case .top:
-      // 위쪽 꼬리 (아래로 향하는 뭉툭한 V)
-      path.move(to: CGPoint(x: rect.midX - 6, y: rect.maxY))
-      path.addLine(to: CGPoint(x: rect.midX - 1, y: rect.minY + 2))
-      path.addQuadCurve(
-        to: CGPoint(x: rect.midX + 1, y: rect.minY + 2),
-        control: CGPoint(x: rect.midX, y: rect.minY)
+      path.move(to: CGPoint(x: rect.minX, y: rect.maxY))
+      path.addCurve(
+        to: CGPoint(x: rect.midX - 4.8, y: rect.minY + 5.625),
+        control1: CGPoint(x: rect.minX + 9, y: rect.maxY),
+        control2: CGPoint(x: rect.minX + 9, y: rect.maxY + 1.25)
       )
-      path.addLine(to: CGPoint(x: rect.midX + 6, y: rect.maxY))
+      path.addQuadCurve(
+        to: CGPoint(x: rect.midX + 4.8, y: rect.minY + 5.625),
+        control: CGPoint(x: rect.midX, y: rect.minY - 3.75)
+      )
+      path.addCurve(
+        to: CGPoint(x: rect.maxX, y: rect.maxY),
+        control1: CGPoint(x: rect.maxX - 9, y: rect.maxY + 1.25),
+        control2: CGPoint(x: rect.maxX - 9, y: rect.maxY)
+      )
       path.closeSubpath()
       
     case .bottom:
-      // 아래쪽 꼬리 (위로 향하는 뭉툭한 V)
-      path.move(to: CGPoint(x: rect.midX - 6, y: rect.minY))
-      path.addLine(to: CGPoint(x: rect.midX - 1, y: rect.maxY - 2))
-      path.addQuadCurve(
-        to: CGPoint(x: rect.midX + 1, y: rect.maxY - 2),
-        control: CGPoint(x: rect.midX, y: rect.maxY)
+      path.move(to: CGPoint(x: rect.minX, y: rect.minY))
+      path.addCurve(
+        to: CGPoint(x: rect.midX - 4.8, y: rect.maxY - 5.625),
+        control1: CGPoint(x: rect.minX + 9, y: rect.minY),
+        control2: CGPoint(x: rect.minX + 9, y: rect.minY - 1.25)
       )
-      path.addLine(to: CGPoint(x: rect.midX + 6, y: rect.minY))
-      path.closeSubpath()
-      
-    case .left:
-      // 왼쪽 꼬리 (오른쪽으로 향하는 뭉툭한 V)
-      path.move(to: CGPoint(x: rect.maxX, y: rect.midY - 6))
-      path.addLine(to: CGPoint(x: rect.minX + 2, y: rect.midY - 1))
       path.addQuadCurve(
-        to: CGPoint(x: rect.minX + 2, y: rect.midY + 1),
-        control: CGPoint(x: rect.minX, y: rect.midY)
+        to: CGPoint(x: rect.midX + 4.8, y: rect.maxY - 5.625),
+        control: CGPoint(x: rect.midX, y: rect.maxY + 3.75)
       )
-      path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY + 6))
-      path.closeSubpath()
-      
-    case .right:
-      // 오른쪽 꼬리 (왼쪽으로 향하는 뭉툭한 V)
-      path.move(to: CGPoint(x: rect.minX, y: rect.midY - 6))
-      path.addLine(to: CGPoint(x: rect.maxX - 2, y: rect.midY - 1))
-      path.addQuadCurve(
-        to: CGPoint(x: rect.maxX - 2, y: rect.midY + 1),
-        control: CGPoint(x: rect.maxX, y: rect.midY)
+      path.addCurve(
+        to: CGPoint(x: rect.maxX, y: rect.minY),
+        control1: CGPoint(x: rect.maxX - 9, y: rect.minY - 1.25),
+        control2: CGPoint(x: rect.maxX - 9, y: rect.minY)
       )
-      path.addLine(to: CGPoint(x: rect.minX, y: rect.midY + 6))
       path.closeSubpath()
     }
-    
     return path
   }
 }

--- a/Projects/Core/DesignKit/Sources/Component/CoachMark/CoachMark.swift
+++ b/Projects/Core/DesignKit/Sources/Component/CoachMark/CoachMark.swift
@@ -48,6 +48,9 @@ public struct CoachMark: View {
           isVisible = false
           action?()
         }
+        .onDisappear {
+          action?()
+        }
       case .bottom:
         VStack(spacing: .Number0) {
           ContentView
@@ -56,6 +59,9 @@ public struct CoachMark: View {
         }
         .onTapGesture {
           isVisible = false
+          action?()
+        }
+        .onDisappear {
           action?()
         }
       }

--- a/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Size+.swift
@@ -29,9 +29,11 @@ public extension CGFloat {
   static let Number28: CGFloat = 28
   static let Number30: CGFloat = 30
   static let Number32: CGFloat = 32
+  static let Number36: CGFloat = 36
   static let Number40: CGFloat = 40
   static let Number48: CGFloat = 48
   static let Number50: CGFloat = 50
+  static let Number54: CGFloat = 54
   static let Number56: CGFloat = 56
   static let Number64: CGFloat = 64
   static let Number72: CGFloat = 72

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -31,6 +31,7 @@ public struct HomeFeature {
     public var isHiddenReportButton: Bool = false
     public var path = StackState<Path.State>()
     public var isPresentDetail: Bool = false
+    public var isShowSuggestionCoachMark: Bool = UserDefaultsKeys.coachMark_suggestion ?? true
     public var toastMessage: String? = nil
     public var isInitAppear: Bool = true
     public init() {}
@@ -48,6 +49,8 @@ public struct HomeFeature {
     case presentDetailView(Bool, id: Int? = nil)
     case presentAlert(AlertType)
     case hiddenReportButton(Bool)
+    
+    case removeSuggestionCoachMark
     
     case showReportView(detail: TrashSpotDetail?)
     case moveToSetting
@@ -118,6 +121,11 @@ public struct HomeFeature {
         state.isHiddenReportButton = isHidden
         return .none
         
+      case .removeSuggestionCoachMark:
+        UserDefaultsKeys.coachMark_suggestion = false
+        state.isShowSuggestionCoachMark = false
+        return .none
+        
       case let .showReportView(detail):
         guard let detail = detail else { return .none }
         state.path.append(
@@ -142,6 +150,7 @@ public struct HomeFeature {
 
       case let .presentDetailView(isPresent, id):
         state.isPresentDetail = isPresent
+        if isPresent { state.isShowSuggestionCoachMark = false }
         let isPathEmpty = state.path.isEmpty
         return .run { send in
           await MainActor.run {

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -42,11 +42,14 @@ public struct HomeView: View {
           }
           .padding(.bottom, (store.isPresentDetail ? bottomSheetHeight : tabbarHeight) + bottomPadding )
         }
-        VStack {
-          TopButtonView
-          Spacer()
+        ZStack {
+          VStack {
+            TopButtonView
+            Spacer()
+            BottomButtonView
+          }
           SnackBarView
-          BottomButtonView
+            .padding(.bottom, (store.isPresentDetail ? bottomSheetHeight : tabbarHeight) + bottomPadding )
         }
       }
       .ignoresSafeArea(edges: .bottom)
@@ -103,11 +106,13 @@ public struct HomeView: View {
     HStack(spacing: .Number8) {
       if store.isPresentDetail {
         IconButton(icon: .leftChevron) {
+          store.send(.removeSuggestionCoachMark)
           store.send(.presentDetailView(false))
           store.send(.map(.deleteActiveMarker))
         }
       }
       TrashFilterView { type in
+        store.send(.removeSuggestionCoachMark)
         store.send(.map(.filterTapped(type)))
       }
     }
@@ -121,11 +126,11 @@ public struct HomeView: View {
     HStack(alignment: .bottom) {
       Spacer()
       VStack(alignment: .trailing, spacing: .Number12) {
-        if let coach = UserDefaultsKeys.coachMark_suggestion, coach {
+        if store.isShowSuggestionCoachMark {
           CoachMark(
             text: "내 주변 가로 쓰레기통을\n등록해보세요",
             offset: .Number100
-          ) { UserDefaultsKeys.coachMark_suggestion = false }
+          ) { store.send(.removeSuggestionCoachMark) }
           .position(.bottom)
         }
         SuggestionButton
@@ -147,6 +152,7 @@ public struct HomeView: View {
   @ViewBuilder
   private var UserLocationButton: some View {
     IconButton(icon: .myLocation) {
+      store.send(.removeSuggestionCoachMark)
       store.send(.location(.fetchCurrentLocation(true)))
     }
   }
@@ -155,6 +161,7 @@ public struct HomeView: View {
   private var SuggestionButton: some View {
     if !store.isHiddenReportButton {
       IconButton(icon: .addSpot, type: .accent) {
+        store.send(.removeSuggestionCoachMark)
         store.send(.suggestionButtonTapped)
       }
     }

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -8,6 +8,7 @@
 
 import SwiftUI
 import Utility
+import UserDefaults
 import DesignKit
 import ComposableArchitecture
 
@@ -32,6 +33,15 @@ public struct HomeView: View {
       ZStack {
         MapView
         .ignoresSafeArea()
+        if store.map.researchButtonEnable {
+          VStack {
+            Spacer()
+            ResearchButton {
+              store.send((.map(.requestMapBounds(true))))
+            }
+          }
+          .padding(.bottom, (store.isPresentDetail ? bottomSheetHeight : tabbarHeight) + bottomPadding )
+        }
         VStack {
           TopButtonView
           Spacer()
@@ -110,11 +120,7 @@ public struct HomeView: View {
   private var BottomButtonView: some View {
     HStack(alignment: .bottom) {
       Spacer()
-        .frame(width: .Number40, height: .Number40)
-      Spacer()
-      if store.map.researchButtonEnable {
-        ResearchButton {
-          store.send((.map(.requestMapBounds(true))))
+      VStack(alignment: .trailing, spacing: .Number12) {
         if let coach = UserDefaultsKeys.coachMark_suggestion, coach {
           CoachMark(
             text: "내 주변 가로 쓰레기통을\n등록해보세요",
@@ -122,9 +128,6 @@ public struct HomeView: View {
           ) { UserDefaultsKeys.coachMark_suggestion = false }
           .position(.bottom)
         }
-      }
-      Spacer()
-      VStack(spacing: .Number12) {
         SuggestionButton
         UserLocationButton
       }

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -39,7 +39,7 @@ public struct HomeView: View {
               store.send((.map(.requestMapBounds(true))))
             }
           }
-          .padding(.bottom, (store.isPresentDetail ? bottomSheetHeight : tabbarHeight) + bottomPadding )
+          .padding(.bottom, (store.isPresentDetail ? store.bottomSheetHeight : tabbarHeight) + bottomPadding )
         }
         ZStack {
           VStack {
@@ -48,7 +48,7 @@ public struct HomeView: View {
             BottomButtonView
           }
           SnackBarView
-            .padding(.bottom, (store.isPresentDetail ? bottomSheetHeight : tabbarHeight) + bottomPadding )
+            .padding(.bottom, (store.isPresentDetail ? store.bottomSheetHeight : tabbarHeight) + bottomPadding )
         }
       }
       .ignoresSafeArea(edges: .bottom)

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -115,6 +115,12 @@ public struct HomeView: View {
       if store.map.researchButtonEnable {
         ResearchButton {
           store.send((.map(.requestMapBounds(true))))
+        if let coach = UserDefaultsKeys.coachMark_suggestion, coach {
+          CoachMark(
+            text: "내 주변 가로 쓰레기통을\n등록해보세요",
+            offset: .Number100
+          ) { UserDefaultsKeys.coachMark_suggestion = false }
+          .position(.bottom)
         }
       }
       Spacer()

--- a/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
@@ -27,4 +27,8 @@ public struct UserDefaultsKeys {
   @UserDefault("lastEntryDate", default: nil)
   public static var lastEntryDate: Date?
   
+  // coachMark
+  @UserDefault("coachMark_suggestion", default: true)
+  public static var coachMark_suggestion: Bool?
+  
 }

--- a/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
@@ -28,7 +28,7 @@ public struct UserDefaultsKeys {
   public static var lastEntryDate: Date?
   
   // coachMark
-  @UserDefault("coachMark_suggestion", default: true)
+  @UserDefault("coachMark_suggestion", default: nil)
   public static var coachMark_suggestion: Bool?
   
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #95 

## 🔎 작업 내용
- 초기 앱 진입시 코치마크가 등장하도록 합니다.

## 📷 스크린샷
<img width="250" alt="IMG_8178" src="https://github.com/user-attachments/assets/6c780f8a-38be-4aee-ae72-79d4f4edd236" />

## 🛠️ 기타 공유 내용
- 코치마크 적용하면서, HomeView 계층을 조금 수정했습니답
- 코치마크 상태관리가 나중에는 여러 케이스로 필요할 것 같긴 해요

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a contextual, dismissible coach mark on Home that suggests registering nearby trash bins; dismissal is persisted and it won’t reappear.
  * Added a bottom research button that appears when available and refreshes the current map area.

* **UX Improvements**
  * Refined coach mark visuals and pointer; placement limited to top or bottom.
  * Coach mark now hides on tap and after related interactions; Home layout adjusted to avoid overlaps with snack bars and bottom controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->