### PR TITLE
레벨업 화면 구현

### DIFF
--- a/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
@@ -45,29 +45,37 @@ public struct LevelBar: View {
     self.addPoint = addPoint
     self.maxLevelPoint = currentLevel.goalPoint
     self._startAnimation = startAnimation
-    self._displayLevel = State(initialValue: currentLevel)
+    
+    // 애니메이션 시작을 위해 역산된 레벨 계산
+    let startingPoint = max(0, currentPoint - addPoint)
+    let calculatedStartLevel = CatLevel.fromPoint(startingPoint)
+    self._displayLevel = State(initialValue: calculatedStartLevel)
   }
   
   private var initialProgress: CGFloat {
-    guard maxLevelPoint > 0 else { return 0 }
-    return CGFloat(currentPoint) / CGFloat(maxLevelPoint)
+    guard displayLevel.goalPoint > 0 else { return 0 }
+    let startingPoint = max(0, currentPoint - addPoint)
+    let startingPointInCurrentLevel = startingPoint % displayLevel.goalPoint
+    return CGFloat(startingPointInCurrentLevel) / CGFloat(displayLevel.goalPoint)
   }
   
   private var finalProgress: CGFloat {
-    guard maxLevelPoint > 0 else { return 0 }
-    return CGFloat(currentPoint + addPoint) / CGFloat(maxLevelPoint)
+    guard displayLevel.goalPoint > 0 else { return 0 }
+    let currentPointInLevel = currentPoint % displayLevel.goalPoint
+    return CGFloat(currentPointInLevel) / CGFloat(displayLevel.goalPoint)
   }
   
   /// 레벨업 가능 여부
   private var willLevelUp: Bool {
-    guard currentLevel != .level5 else { return false }
-    return currentPoint + addPoint >= maxLevelPoint
+    guard displayLevel != .level5 else { return false }
+    let startingPoint = max(0, currentPoint - addPoint)
+    return CatLevel.fromPoint(startingPoint) != currentLevel
   }
   
   /// 레벨업 후 남은 올려야 할 남은 포인트
   private var remainingPointAfterLevelUp: Int {
     guard willLevelUp else { return 0 }
-    return (currentPoint + addPoint) - maxLevelPoint
+    return currentPoint % currentLevel.goalPoint
   }
   
   private var isMaxLevel: Bool {
@@ -153,11 +161,9 @@ public struct LevelBar: View {
     
     // 레벨업 후 남은 포인트로 새로운 progressbar 시작
     DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
-      // 레벨업
-      if let newLevel = currentLevel.nextLevel {
-        displayLevel = newLevel
-        isLevelingUp = true
-      }
+      // 레벨 텍스트 변경과 함께 레벨업
+      displayLevel = currentLevel
+      isLevelingUp = true
       
       // progressbar 리셋 후 남은 포인트만큼 채우기
       animatedProgress = 0
@@ -198,6 +204,20 @@ extension CatLevel {
       return 300
     case .level5:
       return 300
+    }
+  }
+  
+  static func fromPoint(_ point: Int) -> CatLevel {
+    if point >= 300 {
+      return .level5
+    } else if point >= 220 {
+      return .level4
+    } else if point >= 110 {
+      return .level3
+    } else if point >= 20 {
+      return .level2
+    } else {
+      return .level1
     }
   }
 }

--- a/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
@@ -56,24 +56,30 @@ public struct LevelBar: View {
   }
   
   private var initialProgress: CGFloat {
-    guard displayLevel.goalPoint > 0 else { return 0 }
     if currentLevel == .level5 {
       return 1.0
-    } else {
-      let startingPoint = max(0, currentPoint - addPoint)
-      let startingPointInCurrentLevel = startingPoint % displayLevel.goalPoint
-      return CGFloat(startingPointInCurrentLevel) / CGFloat(displayLevel.goalPoint)
     }
+    
+    let startingPoint = max(0, currentPoint - addPoint)
+    let levelStartPoint = displayLevel.startPoint
+    let levelRange = displayLevel.goalPoint - levelStartPoint
+    guard levelRange > 0 else { return 0 }
+    
+    let startingPointInCurrentLevel = max(0, startingPoint - levelStartPoint)
+    return CGFloat(startingPointInCurrentLevel) / CGFloat(levelRange)
   }
   
   private var finalProgress: CGFloat {
-    guard displayLevel.goalPoint > 0 else { return 0 }
     if currentLevel == .level5 {
       return 1.0
-    } else {
-      let currentPointInLevel = currentPoint % displayLevel.goalPoint
-      return CGFloat(currentPointInLevel) / CGFloat(displayLevel.goalPoint)
     }
+    
+    let levelStartPoint = currentLevel.startPoint
+    let levelRange = currentLevel.goalPoint - levelStartPoint
+    guard levelRange > 0 else { return 0 }
+    
+    let currentPointInLevel = currentPoint - levelStartPoint
+    return CGFloat(currentPointInLevel) / CGFloat(levelRange)
   }
   
   /// 레벨업 가능 여부
@@ -86,7 +92,7 @@ public struct LevelBar: View {
   /// 레벨업 후 남은 올려야 할 남은 포인트
   private var remainingPointAfterLevelUp: Int {
     guard willLevelUp else { return 0 }
-    return currentPoint % currentLevel.goalPoint
+    return currentPoint - currentLevel.startPoint
   }
   
   private var isMaxLevel: Bool {
@@ -213,6 +219,21 @@ extension CatLevel {
       return 220
     case .level4:
       return 300
+    case .level5:
+      return 300
+    }
+  }
+  
+  var startPoint: Int {
+    switch self {
+    case .level1:
+      return 0
+    case .level2:
+      return 20
+    case .level3:
+      return 110
+    case .level4:
+      return 220
     case .level5:
       return 300
     }

--- a/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
+++ b/Projects/Core/DesignKit/Sources/Component/LevelBar/LevelBar.swift
@@ -46,23 +46,34 @@ public struct LevelBar: View {
     self.maxLevelPoint = currentLevel.goalPoint
     self._startAnimation = startAnimation
     
-    // 애니메이션 시작을 위해 역산된 레벨 계산
-    let startingPoint = max(0, currentPoint - addPoint)
-    let calculatedStartLevel = CatLevel.fromPoint(startingPoint)
-    self._displayLevel = State(initialValue: calculatedStartLevel)
+    if currentLevel == .level5 {
+      self._displayLevel = State(initialValue: currentLevel)
+    } else {
+      let startingPoint = max(0, currentPoint - addPoint)
+      let calculatedStartLevel = CatLevel.fromPoint(startingPoint)
+      self._displayLevel = State(initialValue: calculatedStartLevel)
+    }
   }
   
   private var initialProgress: CGFloat {
     guard displayLevel.goalPoint > 0 else { return 0 }
-    let startingPoint = max(0, currentPoint - addPoint)
-    let startingPointInCurrentLevel = startingPoint % displayLevel.goalPoint
-    return CGFloat(startingPointInCurrentLevel) / CGFloat(displayLevel.goalPoint)
+    if currentLevel == .level5 {
+      return 1.0
+    } else {
+      let startingPoint = max(0, currentPoint - addPoint)
+      let startingPointInCurrentLevel = startingPoint % displayLevel.goalPoint
+      return CGFloat(startingPointInCurrentLevel) / CGFloat(displayLevel.goalPoint)
+    }
   }
   
   private var finalProgress: CGFloat {
     guard displayLevel.goalPoint > 0 else { return 0 }
-    let currentPointInLevel = currentPoint % displayLevel.goalPoint
-    return CGFloat(currentPointInLevel) / CGFloat(displayLevel.goalPoint)
+    if currentLevel == .level5 {
+      return 1.0
+    } else {
+      let currentPointInLevel = currentPoint % displayLevel.goalPoint
+      return CGFloat(currentPointInLevel) / CGFloat(displayLevel.goalPoint)
+    }
   }
   
   /// 레벨업 가능 여부

--- a/Projects/Domain/Pet/PetDomain/Sources/CheckPetInfoUseCaseImpl.swift
+++ b/Projects/Domain/Pet/PetDomain/Sources/CheckPetInfoUseCaseImpl.swift
@@ -9,6 +9,7 @@
 import Foundation
 import Utility
 import PetDomainInterface
+import UserDefaults
 
 extension CheckPetInfoUseCase {
   public static func live(repository: PetRepository) -> CheckPetInfoUseCase {
@@ -20,6 +21,9 @@ extension CheckPetInfoUseCase {
         switch error {
         case .fileNotFound:
           let newEntity = try await repository.getPetInfo()
+          if UserDefaultsKeys.current_catlevel ?? 1 < newEntity.levelType.rawInt {
+            UserDefaultsKeys.isNeedLevelUp = true
+          }
           return newEntity
         default : throw error
         }

--- a/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpFeature.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpFeature.swift
@@ -1,0 +1,36 @@
+//
+//  LevelUpFeature.swift
+//
+//  LevelUp
+//
+//  Created by Jiyeon
+//
+
+import ComposableArchitecture
+
+@Reducer
+public struct LevelUpFeature {
+  
+  public init() {
+    
+  }
+  
+  @ObservableState
+  public struct State: Equatable {
+    
+    public init() {}
+  }
+
+  public enum Action: BindableAction, Equatable {
+    case binding(BindingAction<State>)
+  }
+
+  public var body: some ReducerOf<Self> {
+    BindingReducer()
+    Reduce { state, action in
+      switch action {
+        default: return .none
+      }
+    }
+  }
+}

--- a/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpFeature.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpFeature.swift
@@ -7,6 +7,10 @@
 //
 
 import ComposableArchitecture
+import PetDomainInterface
+import DesignKit
+import DotLottie
+import UserDefaults
 
 @Reducer
 public struct LevelUpFeature {
@@ -17,20 +21,94 @@ public struct LevelUpFeature {
   
   @ObservableState
   public struct State: Equatable {
+    let petInfo: PetInfoEntity
+    let catLevel: CatLevel
+    let animationState: AnimationState = .init()
+    var showConfetti: Bool = false
+    var showButton: Bool = false
     
-    public init() {}
+    public init(petInfo: PetInfoEntity) {
+      self.catLevel = petInfo.levelType
+      self.petInfo = petInfo
+    }
   }
 
   public enum Action: BindableAction, Equatable {
     case binding(BindingAction<State>)
+    case onAppear
+    case startAnimation
+    case confirmButtonTapped
+    case animation(LevelUpAnimationAction)
+    
+    case dismiss
+    case delegate(Delegate)
+  }
+  
+  public enum Delegate: Equatable {
+    case dismiss
   }
 
   public var body: some ReducerOf<Self> {
     BindingReducer()
     Reduce { state, action in
       switch action {
+      case .onAppear:
+        return .send(.startAnimation)
+        
+      case .startAnimation:
+        return startAnimaion()
+        
+      case let .animation(animation):
+        switch animation {
+        case .confetti:
+          state.animationState.confetti.play()
+          state.showConfetti = true
+          return .none
+          
+        case .showButton:
+          state.showButton = true
+          return .none
+        }
+        
+      case .confirmButtonTapped:
+        UserDefaultsKeys.current_catlevel = state.catLevel.rawInt
+        UserDefaultsKeys.isNeedLevelUp = false
+        return .send(.dismiss)
+        
+      case .dismiss:
+        return .send(.delegate(.dismiss))
+        
         default: return .none
       }
+    }
+  }
+  
+  private func startAnimaion() -> Effect<Action> {
+    return .run { send in
+      try await Task.sleep(for: .seconds(0.4))
+      await send(.animation(.confetti))
+      
+      try await Task.sleep(for: .seconds(0.8))
+      await send(.animation(.showButton))
+    }
+  }
+}
+
+
+extension LevelUpFeature {
+  public enum LevelUpAnimationAction: Equatable {
+    case confetti
+    case showButton
+  }
+  
+  public struct AnimationState: Equatable {
+    var confetti = DotLottieAnimation(
+      fileName: LottieSet.confetti.name,
+      config: AnimationConfig(autoplay: false, loop: false)
+    )
+    
+    public static func == (lhs: LevelUpFeature.AnimationState, rhs: LevelUpFeature.AnimationState) -> Bool {
+      return true
     }
   }
 }

--- a/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpView.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpView.swift
@@ -1,0 +1,24 @@
+//
+//  LevelUpView.swift
+//
+//  LevelUp
+//
+//  Created by Jiyeon
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+public struct LevelUpView: View {
+  @Bindable var store: StoreOf<LevelUpFeature>
+
+  public init(store: StoreOf<LevelUpFeature>) {
+    self.store = store
+  }
+
+  public var body: some View {
+    EmptyView()
+  }
+}
+
+

--- a/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpView.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeature/Sources/LevelUpView.swift
@@ -8,6 +8,8 @@
 
 import SwiftUI
 import ComposableArchitecture
+import DesignKit
+import DotLottie
 
 public struct LevelUpView: View {
   @Bindable var store: StoreOf<LevelUpFeature>
@@ -17,8 +19,83 @@ public struct LevelUpView: View {
   }
 
   public var body: some View {
-    EmptyView()
+    ZStack {
+      ColorSet.Background.Primary
+      ZStack {
+        LevelUpView
+        BottomView
+      }
+    }
+    .background(ColorSet.Background.Primary.ignoresSafeArea())
+    .onAppear {
+      store.send(.onAppear)
+    }
   }
+  
+  @ViewBuilder
+  private var LevelUpView: some View {
+    ZStack{
+      ColorSet.Background.Primary
+      ConfettiView
+      VStack(alignment: .center, spacing: .Number16) {
+        Spacer()
+        Image(
+          asset: CatImageSet.imgae(
+            level: store.catLevel,
+            interaction: false,
+            type: ._2025_07
+          )
+        )
+        .resizable()
+        .aspectRatio(1, contentMode: .fit)
+        .frame(height: .Number200)
+        
+        Text("축하해요!")
+          .font(FontSet.Heading.heading1)
+          .foregroundStyle(ColorSet.Text.Primary)
+        HStack(spacing: .Number0) {
+          Text(store.catLevel.levelText + " " + store.petInfo.nickname)
+            .foregroundStyle(ColorSet.Text.Accent)
+          Text("로 레벨업했어요")
+            .foregroundStyle(ColorSet.Text.Secondary)
+        }
+        .font(FontSet.Body.body3)
+        
+        Spacer()
+      }
+    }
+  }
+  
+  @ViewBuilder
+  private var BottomView: some View {
+    VStack {
+      Spacer()
+      PrimaryButton(
+        title: .constant("확인"),
+        state: .constant(.normal)
+      ) {
+        store.send(.confirmButtonTapped)
+      }
+      .padding(.Number16)
+      .opacity(store.showButton ? 1 : 0)
+      .animation(.easeIn(duration: 0.3), value: store.showButton)
+      .allowsHitTesting(store.showButton)
+    }
+  }
+  
+  @ViewBuilder
+  private var ConfettiView: some View {
+    if store.showConfetti {
+      VStack(alignment: .center, spacing: .Number0) {
+        DotLottieView(dotLottie: store.animationState.confetti)
+          .scaleEffect(2.5)
+          .frame(height: 600)
+          .clipped()
+        Spacer()
+      }
+    }
+  }
+  
 }
 
 

--- a/Projects/Feature/LevelUp/LevelUpFeatureDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Projects/Feature/LevelUp/LevelUpFeatureDemo/Resources/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,35 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "tinted"
+        }
+      ],
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Feature/LevelUp/LevelUpFeatureDemo/Resources/Assets.xcassets/Contents.json
+++ b/Projects/Feature/LevelUp/LevelUpFeatureDemo/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,7 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+

--- a/Projects/Feature/LevelUp/LevelUpFeatureDemo/Sources/LevelUpDemoApp.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeatureDemo/Sources/LevelUpDemoApp.swift
@@ -1,0 +1,25 @@
+//
+//  LevelUpDemoApp.swift
+//
+//  LevelUp
+//
+//  Created by Jiyeon
+//
+
+import SwiftUI
+import ComposableArchitecture
+
+@main
+struct LevelUpDemoApp: App {
+  let store = Store(initialState: LevelUpReducer.State(), reducer: {
+    LevelUpReducer()
+  })
+
+  var body: some Scene {
+    WindowGroup {
+      LevelUpView(store: store)
+    }
+  }
+}
+
+

--- a/Projects/Feature/LevelUp/LevelUpFeatureTesting/Sources/LevelUpUnitTests.swift
+++ b/Projects/Feature/LevelUp/LevelUpFeatureTesting/Sources/LevelUpUnitTests.swift
@@ -1,0 +1,29 @@
+//
+//  LevelUpXCTest.swift
+//
+//  LevelUp
+//
+//  Created by Jiyeon
+//
+
+import Testing
+import ComposableArchitecture
+
+@testable import LevelUp
+
+@MainActor
+struct LevelUpFeatureTest {
+  @Test
+  func addTest() async {
+    let store = TestStore(
+      initialState: LevelUpFeature.State(),
+      reducer: { LevelUpFeature() }
+    )
+    
+    await store.send(\.addButtonTapped) {
+      $0.count += 1
+    }
+  }
+  
+}
+

--- a/Projects/Feature/LevelUp/Project.swift
+++ b/Projects/Feature/LevelUp/Project.swift
@@ -1,0 +1,18 @@
+//
+//  LevelUpProject.swift
+//
+//  LevelUp
+//
+//  Created by Jiyeon
+//
+
+import ProjectDescription
+import ProjectDescriptionHelpers
+
+let project = Project.makeFeature(
+  for: Feature.LevelUp,
+  dependencies: [
+    .Domain.Umbrella
+  ]
+)
+

--- a/Projects/Feature/Project.swift
+++ b/Projects/Feature/Project.swift
@@ -22,7 +22,8 @@ let project = Project.makeStaticLibraryProject(
     .Features.SelectSpotName,
     .Features.MyPage,
     .Features.Visited,
-    .Features.Attendance
+    .Features.Attendance,
+    .Features.LevelUp
   ]
 )
 

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/VisitedFeature.swift
@@ -37,7 +37,7 @@ public struct VisitedFeature {
     
     public var checkComplete: Bool = false
     
-    var petInfo: PetInfoEntity? = nil
+    var isTodayFirst: Bool = false
     
     public var timer: TimerFeature.State = .init()
   }
@@ -152,14 +152,18 @@ public struct VisitedFeature {
         guard state.visitedState == .enableVisit else {
           return .send(.disableVisit)
         }
+        guard let spotId = state.trashSpotId else {
+          return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
+        }
         return .merge([
           .send(.changeVisitedState(.notDetermine)),
-          .send(.fetchPetInfo)
+          requestVisited(spotId: spotId)
         ])
         
       case let .requestVisitResult(.success(result)):
+        state.isTodayFirst = result.isTodayFirst
         return .merge([
-          .send(.visitedComplete(isFirst: result.isTodayFirst, petInfo: state.petInfo)),
+          .send(.fetchPetInfo),
           .send(.successVisit(date: result.visitedAt))
         ])
         
@@ -214,13 +218,10 @@ public struct VisitedFeature {
         return fetchPetInfo()
         
       case let .fetchPetInfoResult(.success(entity)):
-        state.petInfo = entity
-        guard let spotId = state.trashSpotId else {
-          return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
-        }
-        return requestVisited(spotId: spotId)
+        return .send(.visitedComplete(isFirst: state.isTodayFirst, petInfo: entity))
         
       case let .fetchPetInfoResult(.failure(error)):
+        print(error.localizedDescription)
         guard let spotId = state.trashSpotId else {
           return .send(.showToastMessage("쓰레기통 정보를 불러오지 못했어요"))
         }

--- a/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
+++ b/Projects/Shared/UserDefaults/Sources/UserDefaultsKeys.swift
@@ -9,6 +9,9 @@
 import Foundation
 
 public struct UserDefaultsKeys {
+  
+  // MARK: - User
+  
   @UserDefault("accessToken", default: nil)
   public static var accessToken: String?
   
@@ -24,8 +27,17 @@ public struct UserDefaultsKeys {
   @UserDefault("userNickname", default: nil)
   public static var userNickname: String?
   
-  // coachMark
+  // MARK: - CoachMark
+  
   @UserDefault("coachMark_suggestion", default: nil)
   public static var coachMark_suggestion: Bool?
+  
+  // MARK: - Level
+  
+  @UserDefault("current_catlevel", default: 1)
+  public static var current_catlevel: Int?
+  
+  @UserDefault("isNeedLevelUp", default: false)
+  public static var isNeedLevelUp: Bool? // true일 경우 레벨업 화면 등장
   
 }

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -21,7 +21,7 @@ struct UserEntryFeature {
   @ObservableState
   struct State {
     @Presents var modal: Modal.State?
-    var petInfo: PetInfoEntity? = nil
+    var attendanceInfo: AttendanceEntity? = nil
     var userId: Int
     
     init(userId: Int) {
@@ -66,7 +66,7 @@ struct UserEntryFeature {
         
         // MARK: - Attendance
       case .checkAttendance:
-        return .send(.fetchPetInfo)
+        return .send(.requestCheckAttendance)
         
       case .requestCheckAttendance:
         return checkAttendance(userId: state.userId)
@@ -75,11 +75,9 @@ struct UserEntryFeature {
         if data.isToday {
           return .send(.checkComplete)
         } else {
-          let attendanceState = AttendanceFeature.State(data, petInfo: state.petInfo)
-          state.modal = .attendance(attendanceState)
-          return .none
+          state.attendanceInfo = data
+          return .send(.fetchPetInfo)
         }
-        
         
       case let .checkAttendanceResult(.failure(error)):
         print(error)
@@ -91,8 +89,13 @@ struct UserEntryFeature {
         return fetchPetInfo()
         
       case let .fetchPetInfoResult(.success(entity)):
-        state.petInfo = entity
-        return .send(.requestCheckAttendance)
+        if let attendance = state.attendanceInfo {
+          let attendanceState = AttendanceFeature.State(attendance, petInfo: entity)
+          state.modal = .attendance(attendanceState)
+          return .none
+        } else {
+          return .send(.checkComplete)
+        }
         
       case let .fetchPetInfoResult(.failure(error)):
         print(error.localizedDescription)

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -41,6 +41,8 @@ struct UserEntryFeature {
     case fetchPetInfo
     case fetchPetInfoResult(Result<PetInfoEntity, NetworkError>)
     
+    case checkLevelUp
+    
     case modal(PresentationAction<Modal.Action>)
   }
   
@@ -101,13 +103,21 @@ struct UserEntryFeature {
         print(error.localizedDescription)
         return .send(.requestCheckAttendance)
         
+      case .checkLevelUp:
+        if UserDefaultsKeys.isNeedLevelUp ?? false {
+          // TODO: - modal 연결
+          return .none
+        } else {
+          return .send(.checkComplete)
+        }
+        
         // MARK: - Attendance Delegate
         
       case let .modal(.presented(.attendance(action))):
         switch action {
         case .delegate(.dismiss):
           state.modal = nil
-          return .send(.checkComplete)
+          return .send(.checkLevelUp)
         default: return .none
         }
         

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -40,11 +40,13 @@ struct UserEntryFeature {
     case checkAttendance
     case requestCheckAttendance
     case checkAttendanceResult(Result<AttendanceEntity, NetworkError>)
+    case moveToAttendanceView(AttendanceEntity, PetInfoEntity)
     
     case fetchPetInfo
     case fetchPetInfoResult(Result<PetInfoEntity, NetworkError>)
     
     case checkLevelUp
+    case moveToLevelUpView(PetInfoEntity)
     
     case modal(PresentationAction<Modal.Action>)
   }
@@ -89,6 +91,11 @@ struct UserEntryFeature {
         print(error)
         return .send(.checkComplete)
         
+      case let .moveToAttendanceView(attendanceInfo, petInfo):
+        let attendanceState = AttendanceFeature.State(attendanceInfo, petInfo: petInfo)
+        state.modal = .attendance(attendanceState)
+        return .none
+        
         // MARK: - Fetch PetInfo
         
       case .fetchPetInfo:
@@ -97,9 +104,7 @@ struct UserEntryFeature {
       case let .fetchPetInfoResult(.success(entity)):
         if let attendance = state.attendanceInfo {
           state.petInfo = entity
-          let attendanceState = AttendanceFeature.State(attendance, petInfo: entity)
-          state.modal = .attendance(attendanceState)
-          return .none
+          return .send(.moveToAttendanceView(attendance, entity))
         } else {
           return .send(.checkComplete)
         }
@@ -113,14 +118,17 @@ struct UserEntryFeature {
       case .checkLevelUp:
         if UserDefaultsKeys.isNeedLevelUp ?? false {
           if let petInfo = state.petInfo {
-            let levelUpState = LevelUpFeature.State(petInfo: petInfo)
-            state.modal = .levelUp(levelUpState)
-            return .none
+            return .send(.moveToLevelUpView(petInfo))
           }
           return .send(.checkComplete)
         } else {
           return .send(.checkComplete)
         }
+        
+      case let .moveToLevelUpView(petInfo):
+        let levelUpState = LevelUpFeature.State(petInfo: petInfo)
+        state.modal = .levelUp(levelUpState)
+        return .none
         
         // MARK: - Attendance Delegate
         

--- a/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
+++ b/Projects/Sseudam/Sources/Feature/UserEntryFeature.swift
@@ -14,6 +14,8 @@ import Utility
 import AttendanceFeature
 import AttendanceDomainInterface
 
+import LevelUpFeature
+
 import PetDomainInterface
 
 @Reducer
@@ -23,6 +25,7 @@ struct UserEntryFeature {
     @Presents var modal: Modal.State?
     var attendanceInfo: AttendanceEntity? = nil
     var userId: Int
+    var petInfo: PetInfoEntity? = nil
     
     init(userId: Int) {
       self.userId = userId
@@ -53,6 +56,7 @@ struct UserEntryFeature {
   @Reducer(state: .equatable, action: .equatable)
   enum Modal {
     case attendance(AttendanceFeature)
+    case levelUp(LevelUpFeature)
   }
   
   @Dependency(\.AttendanceUseCase) var attendanceUseCase
@@ -92,6 +96,7 @@ struct UserEntryFeature {
         
       case let .fetchPetInfoResult(.success(entity)):
         if let attendance = state.attendanceInfo {
+          state.petInfo = entity
           let attendanceState = AttendanceFeature.State(attendance, petInfo: entity)
           state.modal = .attendance(attendanceState)
           return .none
@@ -103,10 +108,16 @@ struct UserEntryFeature {
         print(error.localizedDescription)
         return .send(.requestCheckAttendance)
         
+      // MARK: - LevelUp
+        
       case .checkLevelUp:
         if UserDefaultsKeys.isNeedLevelUp ?? false {
-          // TODO: - modal 연결
-          return .none
+          if let petInfo = state.petInfo {
+            let levelUpState = LevelUpFeature.State(petInfo: petInfo)
+            state.modal = .levelUp(levelUpState)
+            return .none
+          }
+          return .send(.checkComplete)
         } else {
           return .send(.checkComplete)
         }
@@ -118,6 +129,14 @@ struct UserEntryFeature {
         case .delegate(.dismiss):
           state.modal = nil
           return .send(.checkLevelUp)
+        default: return .none
+        }
+        
+      case let .modal(.presented(.levelUp(action))):
+        switch action {
+        case .delegate(.dismiss):
+          state.modal = nil
+          return .send(.checkComplete)
         default: return .none
         }
         

--- a/Projects/Sseudam/Sources/SseudamView.swift
+++ b/Projects/Sseudam/Sources/SseudamView.swift
@@ -15,6 +15,7 @@ import TrashDetailFeature
 import AuthFeature
 import UserDefaults
 import AttendanceFeature
+import LevelUpFeature
 
 struct SseudamView: View {
   @Bindable var store: StoreOf<SseudamFeature> = Store(
@@ -56,6 +57,9 @@ struct SseudamView: View {
     }
     .fullScreenCover(item: $store.scope(state: \.userEntry?.modal?.attendance, action: \.userEntry.modal.attendance)) { store in
       AttendanceView(store: store)
+    }
+    .fullScreenCover(item: $store.scope(state: \.userEntry?.modal?.levelUp, action: \.userEntry.modal.levelUp)) { store in
+      LevelUpView(store: store)
     }
     .transaction { transaction in
       transaction.disablesAnimations = true

--- a/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
+++ b/Tuist/ProjectDescriptionHelpers/TargetDependency+.swift
@@ -37,6 +37,7 @@ public enum Feature: String, ModuleRepresentable {
   case MyPage
   case Visited
   case Attendance
+  case LevelUp
   public var typePath: String { "Feature" }
 }
 
@@ -168,6 +169,7 @@ extension TargetDependency {
     public static let MyPage = Self.project(.feature(.MyPage))
     public static let Visited = Self.project(.feature(.Visited))
     public static let Attendance = Self.project(.feature(.Attendance))
+    public static let LevelUp = Self.project(.feature(.LevelUp))
   }
   
   public struct Domain: TargetDependencyDelegate {


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- 레벨바 로직 변경
- 레벨바 로직 변경에 따라 출석or방문 완료 요청 후 레벨 조회 순서로 변경
- 레벨업 화면 구현
  - 현재 레벨 및 레벨업 필요 여부 UserDefaults로 저장하여 진입 시점에 레벨업 화면 보여주도록 구성
  
## 📷 스크린샷

https://github.com/user-attachments/assets/d9fc684e-6396-4f2e-89bd-5b3c5eb1a9b4


## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduces a Level Up experience with full-screen view, confetti animation, and confirm button; automatically appears when your pet levels up.
  - Integrated into the app’s entry flow, shown after Attendance when applicable.

- Improvements
  - Level bar now displays per-level progress more accurately with smoother level-up animations.
  - Visit flow handles missing trash can info with clearer feedback and tracks “first visit today” status.

- Tests
  - Added unit tests for the Level Up flow.

- Chores
  - Added Level Up module, demo, assets, and user settings to persist level state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->