### PR TITLE
Qa/#101 2차 디자인 QA 및 기능 개선

### DIFF
--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/A3D9FF.colorset/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/A3D9FF.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xFF",
+          "green" : "0xD9",
+          "red" : "0xA3"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/D7E4F8.colorset/Contents.json
+++ b/Projects/Core/DesignKit/Resources/Colors.xcassets/HexColor/D7E4F8.colorset/Contents.json
@@ -1,0 +1,20 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0xF8",
+          "green" : "0xE4",
+          "red" : "0xD7"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/Projects/Core/DesignKit/Sources/Component/CheckBoxButton/CheckBoxButton.swift
+++ b/Projects/Core/DesignKit/Sources/Component/CheckBoxButton/CheckBoxButton.swift
@@ -45,7 +45,9 @@ public struct CheckBoxButton: View {
       if let icon = icon {
         Icon(
           image: icon,
-          size: .Number24
+          size: .Number24,
+          renderingMode: .template,
+          color: state.textColor
         )
         .foregroundColor(state.iconColor)
       }

--- a/Projects/Core/DesignKit/Sources/Resource+/Color+.swift
+++ b/Projects/Core/DesignKit/Sources/Resource+/Color+.swift
@@ -115,6 +115,8 @@ extension DesignKitAsset {
       public static let _006F9D = DesignKitAsset.Colors._006F9D.swiftUIColor
       public static let _9Fd5Fb = DesignKitAsset.Colors._9Fd5Fb.swiftUIColor
       public static let _E0F2Ff = DesignKitAsset.Colors.e0F2Ff.swiftUIColor
+      public static let _D7E4F8 = DesignKitAsset.Colors.d7E4F8.swiftUIColor
+      public static let _A3D9FF = DesignKitAsset.Colors.a3D9Ff.swiftUIColor
     }
   }
 }

--- a/Projects/Data/History/HistoryDataInterface/Sources/DTO/SuggestionAndReportHistoryDTO.swift
+++ b/Projects/Data/History/HistoryDataInterface/Sources/DTO/SuggestionAndReportHistoryDTO.swift
@@ -47,7 +47,7 @@ public extension SuggestionAndReportHistoryDTO {
         id: $0.id,
         imageUrl: $0.imageUrl,
         status: $0.status,
-        address: $0.address.site,
+        address: $0.spotName,
         actionType: $0.actionType,
         date: $0.createdAt
       )

--- a/Projects/Feature/MyPage/MyPageFeature/Sources/Views/SuggestionList/SuggestCell.swift
+++ b/Projects/Feature/MyPage/MyPageFeature/Sources/Views/SuggestionList/SuggestCell.swift
@@ -79,7 +79,3 @@ public struct SuggestCell: View {
   }
   
 }
-
-#Preview {
-    SuggestCell()
-}

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Features/MyPetGrowthListFeature.swift
@@ -82,10 +82,17 @@ extension MyPetGrowthListFeature {
   }
   
   fileprivate func fetchCatCardsAction(with seasonData: PetSeasonInfoEntity) -> Action {
-    let catCards = seasonData.seasonPetInfo.map { item -> CatCard in
-      let imageURL = CatImageSet.imageURL(level: item.levelType, type: item.season)
-      return .init(isLocked: item.isLocked, imageURL: imageURL)
-    }
+    print("seasonData: \(seasonData)")
+    
+    let catCards = Dictionary(grouping: seasonData.seasonPetInfo) { $0.season }
+      .compactMap { _, pets in
+        pets.max { $0.createdAt < $1.createdAt }
+      }
+      .map { pet in
+        let imageURL = CatImageSet.imageURL(level: pet.levelType, type: pet.season)
+        return CatCard(isLocked: pet.isLocked, imageURL: imageURL)
+      }
+    
     return .fetchCatCards(catCards)
   }
   

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/CatCardCell.swift
@@ -39,6 +39,7 @@ public struct CatCardCell: View {
             CatImageSet.image(name: card.imageURL)
               .resizable()
               .scaledToFit()
+              .frame(width: .Number50, height: .Number50)
           }
         }
       )

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/Cells/GrowthRecordCell.swift
@@ -42,8 +42,10 @@ public struct GrowthRecordCell: View {
                 CatImageSet.image(name: record.catCard.imageURL)
                   .resizable()
                   .scaledToFit()
+                  .frame(width: .Number50, height: .Number50)
               }
             }
+            .frame(width: .Number64, height: .Number64)
           )
           .clipCorners(.Number8, corners: .allCorners)
         

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetCardView.swift
@@ -99,7 +99,7 @@ public struct MyPetCardView: View {
           .foregroundStyle(ColorSet.Text.Primary)
       }
     }
-    .padding(.Number20)
+    .padding(.Number16)
     .background(ColorSet.Background.Primary)
     .cornerRadius(.Number10)
     .elevation(level: .elevation, cornerRadius: .Number10)

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetGrowthListView.swift
@@ -41,7 +41,7 @@ public struct BigBottomSheetContentView: View {
   private var SavedCatsView: some View {
     VStack(alignment: .leading, spacing: .Number8) {
       HStack(alignment: .center) {
-        Text("내가 살린 고양이")
+        Text("내가 돌본 고양이")
           .font(FontSet.Body.body3)
           .foregroundStyle(ColorSet.Text.Secondary)
           .padding(.horizontal, .Number16)

--- a/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
+++ b/Projects/Feature/MyPet/MyPetFeature/Sources/Views/MyPetView.swift
@@ -25,14 +25,17 @@ public struct MyPetView: View {
     NavigationStack(
       path: $store.scope(state: \.path, action: \.path)
     ) {
-      ContentView
-        .onAppear() {
-          store.send(.onAppear)
-        }
-        .background(
-          ColorSet.Background.Primary
-            .ignoresSafeArea()
-        )
+      GeometryReader { proxy in
+        let _ = print("MyPetView - proxy.safebottom: \(proxy.safeAreaInsets.bottom)")
+        ContentView(safeAreaBottomInset: proxy.safeAreaInsets.bottom)
+          .onAppear() {
+            store.send(.onAppear)
+          }
+          .background(
+            ColorSet.Background.Primary
+              .ignoresSafeArea()
+          )
+      }
     } destination: { store in
       switch store.case {
       case let .petDetail(store):
@@ -52,11 +55,11 @@ public struct MyPetView: View {
   }
   
   @ViewBuilder
-  private var ContentView: some View {
+  private func ContentView(safeAreaBottomInset: CGFloat) -> some View {
     if store.isLoggedIn {
       ZStack {
         GeometryReader { proxy in
-          MainView
+          MainView(safeAreaBottomInset: safeAreaBottomInset)
             .overlay(alignment: .bottomTrailing) {
               IconButton(icon: .info) {
                 store.send(.petDescriptionButtonTapped)
@@ -90,84 +93,111 @@ public struct MyPetView: View {
   }
   
   @ViewBuilder
-  private var MainView: some View {
+  private func MainView(safeAreaBottomInset: CGFloat) -> some View {
     ZStack {
       VStack {
         Spacer()
-        ColorSet.Mint._100
-          .frame(height: .Number230)
-          .offset(y: -.Number50)
+        LinearGradient(
+          gradient: Gradient(
+            colors: [
+              ColorSet.HexColor._9Fd5Fb,
+              ColorSet.HexColor._A3D9FF
+            ]
+          ),
+          startPoint: .top,
+          endPoint: .bottom
+        )
+        .frame(height: 330 * UIScreen.main.bounds.height / 812 - safeAreaBottomInset)
       }
       
-      VStack {
+      VStack(spacing: .Number0) {
         CardView
           .padding(.Number16)
-        Group {
-          ZStack {
-            Ellipse()
-              .fill(
-                RadialGradient(
-                  gradient: Gradient(stops: [
-                    .init(color: ColorSet.HexColor._006F9D.opacity(0.3), location: 0),
-                    .init(color: ColorSet.HexColor._006F9D.opacity(0), location: 1)
-                  ]),
-                  center: .center,
-                  startRadius: 0,
-                  endRadius: 77
-                )
-              )
-              .frame(width: 153, height: 52)
-              .blur(radius: 6)
-              .offset(y: 90)
-            
-            // 고양이 이미지
-            Image(
-              asset: CatImageSet.imgae(
-                level: store.myPetInfo?.levelType,
-                interaction: store.isMyPetInteracted,
-                type: ._2025_07
-              )
-            )
-            .resizable()
-            .aspectRatio(1, contentMode: .fit)
-            .frame(height: .Number220)
-            .overlay(
-              Color.clear
-                .contentShape(Rectangle())
-                .allowsHitTesting(true)
-                .onTapGesture(coordinateSpace: .global) { location in
-                  let impactFeedback = UIImpactFeedbackGenerator(style: .soft)
-                  impactFeedback.impactOccurred()
-                  
-                  var newLocation = location
-                  newLocation.y -= .Number220
-                  store.send(.catImageTapped(newLocation))
-                }
-            )
-            
-            if store.showBubble {
-              BubbleView(text: store.bubbleText)
-                .offset(x: store.bubbleOffset.x, y: store.bubbleOffset.y)
-                .transition(.scale.combined(with: .opacity))
-                .animation(.spring(response: 0.3, dampingFraction: 0.8), value: store.showBubble)
-                .zIndex(2)
-                .allowsHitTesting(false)
-            }
-            
-            if store.showShineLottieAnimation {
-              TapCatImageWithShine
-                .frame(width: .Number220, height: .Number220)
-                .position(store.tapMyPetLocation)
-                .allowsHitTesting(false)
-                .transition(.opacity)
-                .zIndex(1)
-            }
+        ZStack {
+          CatShadowView
+            .offset(y: 135)
+          CatImageView
+            .padding(.bottom, -(74 * UIScreen.main.bounds.height / 812))
+          
+          if store.showBubble {
+            BubbleView(text: store.bubbleText)
+              .offset(x: store.bubbleOffset.x, y: store.bubbleOffset.y)
+              .transition(.scale.combined(with: .opacity))
+              .animation(.spring(response: 0.3, dampingFraction: 0.8), value: store.showBubble)
+              .zIndex(2)
+              .allowsHitTesting(false)
+          }
+          
+          if store.showShineLottieAnimation {
+            TapCatImageWithShine
+              .frame(width: .Number220, height: .Number220)
+              .position(store.tapMyPetLocation)
+              .allowsHitTesting(false)
+              .transition(.opacity)
+              .zIndex(1)
           }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.bottom, .Number156 + .Number50)
       }
     }
-    .background(ColorSet.Background.Accent)
+    .background(
+      LinearGradient(
+        gradient: Gradient(
+          colors: [
+            ColorSet.HexColor._E0F2Ff,
+            ColorSet.HexColor._D7E4F8
+          ]
+        ),
+        startPoint: .top,
+        endPoint: .bottom
+      )
+    )
+  }
+  
+  @ViewBuilder
+  private var CatShadowView: some View {
+    Ellipse()
+      .fill(
+        RadialGradient(
+          gradient: Gradient(stops: [
+            .init(color: ColorSet.HexColor._006F9D.opacity(0.3), location: 0),
+            .init(color: ColorSet.HexColor._006F9D.opacity(0), location: 1)
+          ]),
+          center: .center,
+          startRadius: 0,
+          endRadius: 77
+        )
+      )
+      .frame(width: 153, height: 52)
+      .blur(radius: 6)
+  }
+  
+  @ViewBuilder
+  private var CatImageView: some View {
+    Image(
+      asset: CatImageSet.imgae(
+        level: store.myPetInfo?.levelType,
+        interaction: store.isMyPetInteracted,
+        type: ._2025_07
+      )
+    )
+    .resizable()
+    .aspectRatio(1, contentMode: .fit)
+    .frame(height: .Number220)
+    .overlay(
+      Color.clear
+        .contentShape(Rectangle())
+        .allowsHitTesting(true)
+        .onTapGesture(coordinateSpace: .global) { location in
+          let impactFeedback = UIImpactFeedbackGenerator(style: .soft)
+          impactFeedback.impactOccurred()
+          
+          var newLocation = location
+          newLocation.y -= .Number220
+          store.send(.catImageTapped(newLocation))
+        }
+    )
   }
   
   @ViewBuilder


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #101 

## 🔎 작업 내용
- 마이펫 페이지 레이아웃 수정
- 쓰레기 종류 선택 아이콘 색상 수정
- 성장기록 캐릭터 이미지 사이즈 조정
- 내가 돌본 고양이 카드 기준 변경
- 쓰레기통 명 표시

## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved safe-area handling on My Pet screens for better layout on devices with home indicators.

- UI/UX
  - Updated My Pet header/background to gradients with new accent colors.
  - Standardized image sizes in cat cards and growth records for consistent thumbnails.
  - Reduced card padding for a tighter layout.
  - Refined checkbox icon rendering for clearer visuals.
  - Changed copy to “내가 돌본 고양이”.

- Behavior Changes
  - Growth list now shows one card per season (latest pet per season).
  - History address now displays the spot name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->