### PR TITLE
이미지 초기화 오류 수정

### DIFF
--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Features/TrashDetailFeature.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import UIKit
 import ComposableArchitecture
 import TrashSpotDomainInterface
 import ImageDownloadDomainInterface
@@ -26,12 +27,12 @@ public struct TrashDetailFeature {
     public var visited: VisitedFeature.State = .init()
     var isEmptyList: Bool = false
     var trashDetail: TrashSpotDetail? = nil
-    var trashImageData: Data? = nil
     var isLoading: Bool = true
     var isFailLoadDetail: Bool = false
     var isNeedUpdateHeight: Bool = true
     var isTitleMultiLine: Bool? = nil
     public var bottomSheetHeight: CGFloat = .detailSheetHeight
+    var downsampledImage: UIImage? = nil
     public init() {}
   }
 
@@ -54,7 +55,7 @@ public struct TrashDetailFeature {
     
     case fetchTrashImage(imgUrl: String?, id: Int)
     case fetchTrashImageResult(Result<Data, ImageDownloadError>)
-    case storeImageData(data: Data?)
+    case storeImageData(data: UIImage?)
     
     /// 로그인 후 상태 변경하기 위한 action
     case checkLoggedin
@@ -151,14 +152,21 @@ public struct TrashDetailFeature {
         return fetchTrashImage(imgUrl: imgUrl, id: id)
         
       case let .fetchTrashImageResult(.success(data)):
-        return .send(.storeImageData(data: data))
+        return .run { send in
+            let image = await UIImage.downsampledAsync(
+            from: data,
+            to: CGSize(width: .Number80, height: .Number80)
+          )
+          await send(.storeImageData(data: image))
+        }
         
       case let .fetchTrashImageResult(.failure(error)):
+        state.downsampledImage = nil
         print(error)
         return .none
         
       case let .storeImageData(data):
-        state.trashImageData = data
+        state.downsampledImage = data
         return .none
         
       case .checkLoggedin:

--- a/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
+++ b/Projects/Feature/TrashDetail/TrashDetailFeature/Sources/Views/TrashDetailView.swift
@@ -16,7 +16,6 @@ import DotLottie
 public struct TrashDetailView: View {
   @Bindable var store: StoreOf<TrashDetailFeature>
   @Environment(\.scenePhase) private var scenePhase
-  @State private var downsampledImage: UIImage?
   
   public init(store: StoreOf<TrashDetailFeature>) {
     self.store = store
@@ -101,7 +100,7 @@ public struct TrashDetailView: View {
   
   @ViewBuilder
   private var trashImageView: some View {
-    if let image = downsampledImage {
+    if let image = store.downsampledImage {
       Image(uiImage: image)
         .resizable()
         .clipShape(RoundedRectangle(cornerRadius: .Number8))
@@ -112,14 +111,6 @@ public struct TrashDetailView: View {
         .fill(ColorSet.Background.Secondary)
         .clipShape(RoundedRectangle(cornerRadius: .Number8))
         .frame(width: .Number80, height: .Number80)
-        .task(id: store.trashImageData) { 
-          if let data = store.trashImageData {
-            downsampledImage = await UIImage.downsampledAsync(
-              from: data,
-              to: CGSize(width: .Number80, height: .Number80)
-            )
-          }
-        }
     }
   }
   

--- a/Projects/Shared/Utility/Sources/Type/ExternalURL.swift
+++ b/Projects/Shared/Utility/Sources/Type/ExternalURL.swift
@@ -12,5 +12,5 @@ public enum ExternalURL {
   public static let serviceTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/23f90c66759880bcbbabe5ba2f1b2650?source=copy_link")
   public static let privacyTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/23f90c66759880b4970ddb06f08e86a8?source=copy_link")
   public static let feedBack: URL? = URL(string: "https://walla.my/survey/BLp7yFuTUe7JI8KXPXvw")
-  public static let appStore: URL? = URL(string: "itms-apps://itunes.apple.com/app/id6751765360")
+  public static let appStore: URL? = URL(string: Constants.APP_STORE_URL)
 }

--- a/Projects/Shared/Utility/Sources/Type/ExternalURL.swift
+++ b/Projects/Shared/Utility/Sources/Type/ExternalURL.swift
@@ -12,5 +12,5 @@ public enum ExternalURL {
   public static let serviceTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/23f90c66759880bcbbabe5ba2f1b2650?source=copy_link")
   public static let privacyTerm: URL? = URL(string: "https://wealthy-session-98c.notion.site/23f90c66759880b4970ddb06f08e86a8?source=copy_link")
   public static let feedBack: URL? = URL(string: "https://walla.my/survey/BLp7yFuTUe7JI8KXPXvw")
-  public static let appStore: URL? = URL(string: "itms-apps://itunes.apple.com/app/id{아이디 추가 필요}")
+  public static let appStore: URL? = URL(string: "itms-apps://itunes.apple.com/app/id6751765360")
 }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- 디테일 모달을 띄운 상태로 다른 쓰레기통 데이터를 눌러 데이터만 교체 될 경우, 이미지가 변경되지 않는 문제가 생김
- downsampleimage state를 뷰에서 관리하고 있었기 때문에 업데이트가 되지 않음. 
- 때문에 downsample 로직을 DetailFeature에서 수행하도록 해서 state가 변경될 때 초기화 되도록 수정함.


## 📷 스크린샷

## 🛠️ 기타 공유 내용
- 다운샘플 로직이 어디에 들어가야하는지 좀 긴가민가 하네요.. UIImage이기 때문에 view에서 해야한다고 생각했는데, 이 또한 상태 관리 대상이고 비동기로 다운받아오기 때문에 비즈니스로직으로 분류를 하는게 맞나 고민하다가 일단 detailfeature에서 수행하도록 해뒀는데 좀 더 고민이 필요할 것 같긴 합니도..


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Images are downsampled before being stored and displayed, reducing memory use and improving load performance.
  - Image state moved to a central feature store; view-level processing removed.
  - UI simplified: image is shown only when available (placeholder removed).

- Bug Fixes
  - App Store link corrected to open the proper listing.

- Chores
  - External App Store URL configuration updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->