### PR TITLE
hotfix: 홈 지도 및 위치 관련 로직 수정

### DIFF
--- a/Projects/Feature/Home/HomeFeature/Sources/Features/MapFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/MapFeature.swift
@@ -27,13 +27,12 @@ public struct MapFeature {
     public var trashType: TrashType? = nil
     /// 활성화 되어있는 마커를 지우기 위한 플래그
     public var isNeedDeleteMarker: Bool = false
-    /// 첫 로드 여부
-    public var isFirstLoad: Bool = true
     /// 확장 검색 여부
     public var isExpandedRetry: Bool = false
     /// 확장 검색 시도 시 필요한 이전 탐색 범위
     public var lastSearchedBounds: [Coordinates]? = nil
     
+    public var isTrashDataFirstLoad: Bool = true
     public init() {}
   }
   
@@ -95,6 +94,7 @@ public struct MapFeature {
         case let .success(items):
           return .send(.storeTrashItems(items))
         case let .failure(error):
+          state.isTrashDataFirstLoad = false
           return .send(.delegate(.showToastMessage(error.localizedDescription)))
         }
         
@@ -104,12 +104,12 @@ public struct MapFeature {
         if items.isEmpty {
           return .send(.emptyTrashItems)
         } else { // 데이터 있으면 바텀시트 내리기
-          state.isFirstLoad = false
+          state.isTrashDataFirstLoad = false
           return .send(.delegate(.presentDetailView(false)))
         }
         
       case .emptyTrashItems:
-        if state.isFirstLoad {
+        if state.isTrashDataFirstLoad {
           return .send(.firstLoadSearch)
         } else { // 바텀시트 띄우기
           return .send(.delegate(.presentDetailView(true, id: nil)))
@@ -120,8 +120,8 @@ public struct MapFeature {
           state.isExpandedRetry = true
           return .send(.expandSearch)
         } else { // 확장 검색 후에도 없음
-          state.isFirstLoad = false
           state.isExpandedRetry = false
+          state.isTrashDataFirstLoad = false
           return .send(
             .delegate(.showToastMessage("이 근방에는 쓰레기통이 없어요.\n지도를 움직여 다른 위치를 확인해보세요!"))
           )

--- a/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewCoordinator.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewCoordinator.swift
@@ -19,8 +19,6 @@ extension MapViewRepresentable {
     
     var isInitialBounds: Bool = true
     
-    var isFirstLoadData: Bool = true
-    
     var trashItems: [TrashSpot] = []
     
     var markers: [NMFMarker] = []

--- a/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
@@ -27,6 +27,8 @@ struct MapViewRepresentable: UIViewRepresentable {
   
   @Binding var isNeedDeleteMarker: Bool
   
+  @Binding var isTrashDataFirstLoad: Bool
+  
   /// 지도 범위 전달 클로저
   var mapBounds: (([Coordinates]) -> Void)? = nil
   /// 마커 탭 시 id값을 전달하기 위한 클로저
@@ -211,7 +213,7 @@ extension MapViewRepresentable {
 extension MapViewRepresentable {
   
   /// 카메라 이동 메서드
-  private func moveCamera(_ view: NMFNaverMapView, to point: Coordinates?, zoomLevel: Double = 18) {
+  private func moveCamera(_ view: NMFNaverMapView, to point: Coordinates?, zoomLevel: Double = 20) {
     if let point = point {
       let coord = NMGLatLng(lat: point.latitude, lng: point.longitude)
       let cameraUpdate = NMFCameraUpdate(scrollTo: coord, zoomTo: zoomLevel)
@@ -230,7 +232,7 @@ extension MapViewRepresentable {
   ) {
     // 카메라 이동
     if !items.isEmpty  {
-      if context.coordinator.isFirstLoadData {
+      if isTrashDataFirstLoad {
         if items.count >= 20 {
           let currentPosition = view.mapView.cameraPosition.target
           let mapPoint: Coordinates = .init(
@@ -241,7 +243,7 @@ extension MapViewRepresentable {
         } else {
           fitMarkersZoomOnly(view: view, items: items)
         }
-        context.coordinator.isFirstLoadData = false
+        isTrashDataFirstLoad = false
       } else {
         fitMarkersInCenter(view: view, items: items)
       }

--- a/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/SubViews/MapViewRepresentable.swift
@@ -156,7 +156,6 @@ extension MapViewRepresentable {
   
   /// 지도에 마커 보여주기
   private func presentMarkers(_ view: NMFNaverMapView, items: [TrashSpot], context: Context) {
-    print(#function, items.count)
     if context.coordinator.trashItems != items {
       deleteDrawMarker(context: context)
     }
@@ -213,7 +212,7 @@ extension MapViewRepresentable {
 extension MapViewRepresentable {
   
   /// 카메라 이동 메서드
-  private func moveCamera(_ view: NMFNaverMapView, to point: Coordinates?, zoomLevel: Double = 20) {
+  private func moveCamera(_ view: NMFNaverMapView, to point: Coordinates?, zoomLevel: Double = 18) {
     if let point = point {
       let coord = NMGLatLng(lat: point.latitude, lng: point.longitude)
       let cameraUpdate = NMFCameraUpdate(scrollTo: coord, zoomTo: zoomLevel)

--- a/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/View/HomeView.swift
@@ -73,7 +73,8 @@ public struct HomeView: View {
       requestMapBounds: $store.map.requestMapBounds,
       trashItems: $store.map.trashItems,
       isMapMove: $store.map.researchButtonEnable,
-      isNeedDeleteMarker: $store.map.isNeedDeleteMarker
+      isNeedDeleteMarker: $store.map.isNeedDeleteMarker,
+      isTrashDataFirstLoad: $store.map.isTrashDataFirstLoad
     )
     .onReceiveMapBounds {
       store.send(.map(.fetchTrashItems($0)))

--- a/Projects/Feature/SelectSpotLocation/SelectSpotLocationFeature/Sources/Features/SelectSpotLocationFeature.swift
+++ b/Projects/Feature/SelectSpotLocation/SelectSpotLocationFeature/Sources/Features/SelectSpotLocationFeature.swift
@@ -114,7 +114,7 @@ extension SelectSpotLocationFeature {
   
   private func moveUserLocation() -> Effect<Action> {
     return .run { send in
-      if let userLocation = await LocationService.shared.userLocation {
+      if let userLocation = await LocationService.shared.requestSingleLocation() {
         await send(.initUserLocation(userLocation))
       }
     }


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- 첫 진입하고 데이터 없음 -> 이후 데이터 조회 시 첫 데이터 조회 로직이 동작하는 문제가 발생함
 - 데이터 조회 후 첫 조회일 경우는 다른 액션을 부여하고 있음 ex) 데이터 20개 이상 시 줌 확대, 데이터 없을 경우 확장 후 재검색 등
 - 첫 조회 여부 상태 관리가 잘 안되고 있어서 이 부분 수정함!
- 제보하기 지도에서 현위치 버튼이 동작 수정

## 📷 스크린샷

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Improvements
  - Smarter initial map behavior: one-time first-load logic now chooses a closer zoom when many items are present or fits markers otherwise.
  - Prevents repeated auto-adjustments after first load for a steadier map view.
  - Consistent first-load handling across the home map.
  - More reliable single-shot user location fetch when selecting a spot, improving centering responsiveness.

- Refactor
  - Internal first-load state and bindings streamlined for clearer map state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->