### PR TITLE
bug: 디테일 제보하기 -> 제보하기 이동 시 바텀시트 오류 수정

### DIFF
--- a/Projects/Core/DesignKit/Sources/Component/PrimaryButton/PrimaryButton.swift
+++ b/Projects/Core/DesignKit/Sources/Component/PrimaryButton/PrimaryButton.swift
@@ -103,6 +103,7 @@ public struct PrimaryButton<Icon: View, LoadingView: View>: View {
     }
     .frame(maxWidth: .infinity)
     .padding(.vertical, isLoading ? .Number4 : size.padding.vertical)
+    .contentShape(Rectangle())
     .background(
       RoundedRectangle(cornerRadius: size.cornerRadius)
         .fill(state.backgroundColor)

--- a/Projects/Core/DesignKit/Sources/Component/SecondaryButton/SecondaryButton.swift
+++ b/Projects/Core/DesignKit/Sources/Component/SecondaryButton/SecondaryButton.swift
@@ -63,8 +63,7 @@ public struct SecondaryButton<Icon: View>: View {
       .gesture(
         DragGesture(minimumDistance: .Number0)
           .onChanged { _ in isPressed = true }
-          .onEnded {
-            _ in
+          .onEnded { _ in
             isPressed = false
             Task { action() }
           }
@@ -83,6 +82,7 @@ public struct SecondaryButton<Icon: View>: View {
     .frame(maxWidth: .infinity)
     .padding(.vertical, size.padding.vertical)
     .padding(.horizontal, size.padding.horizontal)
+    .contentShape(Rectangle()) // 버튼의 패딩 영역도 터치 가능하게 설정
     .overlay(
       RoundedRectangle(cornerRadius: size.cornerRadius)
         .inset(by: 0.5)

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -55,6 +55,7 @@ public struct HomeFeature {
     
     case showReportView(detail: TrashSpotDetail?)
     case moveToSetting
+    case moveToSuggestionFromDetail
     case moveToSuggestion
     case suggestionButtonTapped
     case delegate(Delegate)
@@ -165,6 +166,14 @@ public struct HomeFeature {
           .send(.mixPanel(.reportStart))
         )
         // MARK: - Send Action to HomeRoot
+        
+      case .moveToSuggestionFromDetail:
+        state.isPresentDetail = false
+        
+        return .run { send in
+          await send(.delegate(.presentDetailView(false, id: nil)))
+          await send(.moveToSuggestion)
+        }
         
       case .moveToSuggestion:
         let suggestionState = SuggestionFeature.State(state.location.lastCameraPosition)

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -207,13 +207,19 @@ public struct HomeFeature {
         switch action {
           // MARK: - Suggestion Action
         case .element(id: _, action: .suggestionView(.pop)):
-          state.isShowSuggestionFromDetail = false
           state.path.removeLast()
-          return .send(.presentDetailView(true, id: nil))
+          if state.isShowSuggestionFromDetail {
+            state.isShowSuggestionFromDetail = false
+            return .send(.presentDetailView(true, id: nil))
+          } else {
+            return .none
+          }
           
         case .element(id: _, action: .suggestionView(.complete)):
+          if state.isShowSuggestionFromDetail {
+            state.isShowSuggestionFromDetail = false
+          }
           state.path.removeLast()
-          state.isShowSuggestionFromDetail = false
           return .none
           
         case let .element(id: _, action: .suggestionView(.mixPanel(ev))):

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -207,13 +207,14 @@ public struct HomeFeature {
         switch action {
           // MARK: - Suggestion Action
         case .element(id: _, action: .suggestionView(.pop)):
+          state.isShowSuggestionFromDetail = false
           state.path.removeLast()
-          if state.isShowSuggestionFromDetail {
-            state.isShowSuggestionFromDetail = false
-            return .send(.presentDetailView(true, id: nil))
-          } else {
-            return .none
-          }
+          return .send(.presentDetailView(true, id: nil))
+          
+        case .element(id: _, action: .suggestionView(.complete)):
+          state.path.removeLast()
+          state.isShowSuggestionFromDetail = false
+          return .none
           
         case let .element(id: _, action: .suggestionView(.mixPanel(ev))):
           switch ev {

--- a/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
+++ b/Projects/Feature/Home/HomeFeature/Sources/Features/HomeFeature.swift
@@ -35,6 +35,8 @@ public struct HomeFeature {
     public var toastMessage: String? = nil
     public var isInitAppear: Bool = true
     public var bottomSheetHeight: CGFloat = .detailSheetHeight + .Number10
+    
+    public var isShowSuggestionFromDetail: Bool = false
     public init() {}
   }
 
@@ -169,7 +171,7 @@ public struct HomeFeature {
         
       case .moveToSuggestionFromDetail:
         state.isPresentDetail = false
-        
+        state.isShowSuggestionFromDetail = true
         return .run { send in
           await send(.delegate(.presentDetailView(false, id: nil)))
           await send(.moveToSuggestion)
@@ -206,7 +208,12 @@ public struct HomeFeature {
           // MARK: - Suggestion Action
         case .element(id: _, action: .suggestionView(.pop)):
           state.path.removeLast()
-          return .none
+          if state.isShowSuggestionFromDetail {
+            state.isShowSuggestionFromDetail = false
+            return .send(.presentDetailView(true, id: nil))
+          } else {
+            return .none
+          }
           
         case let .element(id: _, action: .suggestionView(.mixPanel(ev))):
           switch ev {

--- a/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionFeature.swift
+++ b/Projects/Feature/Suggestion/SuggestionFeature/Sources/Features/SuggestionFeature.swift
@@ -93,6 +93,7 @@ public struct SuggestionFeature {
     
     case backButtonTapped
     case pop
+    case complete
     case backPageTapped
     
     public enum MixPanel: Equatable {
@@ -139,7 +140,7 @@ public struct SuggestionFeature {
       case .nextButtonTapped:
         /// 다음 페이지로 넘어가기 전에 현재 페이지에서 검증 action
         if state.currentPage == 2 { return .send(.validateSpotNameButtonTapped) }
-        if state.currentPage == 5 { return .send(.pop) }
+        if state.currentPage == 5 { return .send(.complete) }
         state.currentPage = min(state.currentPage + 1, 5)
         /// 다음 페이지에 따라 적절한 action을 보냄
         switch state.currentPage {
@@ -293,6 +294,9 @@ public struct SuggestionFeature {
         return .none
         
       case .pop:
+        return .none
+        
+      case .complete:
         return .none
       }
     }

--- a/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
+++ b/Projects/Sseudam/Sources/TabRoot/HomeRoot/HomeRootFeature.swift
@@ -193,7 +193,7 @@ struct HomeRootFeature {
           return .send(.home(.showReportView(detail: detailData)))
           
         case .suggestionButtonTapped:
-          return .send(.home(.moveToSuggestion))
+          return .send(.home(.moveToSuggestionFromDetail))
           
         case let .showToastMessage(message):
           return .send(.home(.showToastMessage(message)))


### PR DESCRIPTION
## #️⃣ Issue Number
- issue: #

## 🔎 작업 내용
- 디테일 화면 내 제보하기 버튼 탭 시 바텀시트가 사라지지 않는 오류 수정
- 디테일->제보하기 뒤로가기 pop 시 바텀시트 재등장
- 제보하기 완료 후 바텀시트 등장 플래그 false로 변경
  - SuggestionFeature의 `nextButtonTapped`에서 `currentPage == 5` 일 경우 `.pop` 에서 `.complete`로 전달해서 별도 처리하도록 수정함!

## 📷 스크린샷
|뒤로가기|완료|
|:----:|:----:|
|<img src = "https://github.com/user-attachments/assets/7e1470db-912f-4fd2-b6bb-fccc6f5aee36" width = "270">|<img src =  "https://github.com/user-attachments/assets/96d643f6-408a-485b-89de-65545ab40f99" width = "270">|

## 🛠️ 기타 공유 내용


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enable navigation from detail to Suggestions via a new action and state flag in Home.
  * Add a completion action to the Suggestions flow.

* **Bug Fixes**
  * Expanded tap targets for Primary/Secondary buttons and header tabs for more reliable tapping.
  * Map now switches to direction mode when moving to a new location point.
  * Prevent unintended location updates when authorization is not determined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->